### PR TITLE
Issue #30: Add support for saving into SCC with UTF-8 encoding

### DIFF
--- a/Forms/Access SVN - Options.ACF
+++ b/Forms/Access SVN - Options.ACF
@@ -128,12 +128,14 @@ Begin Form
         Begin Rectangle
             SpecialEffect =3
             BackStyle =0
+            BorderLineStyle =0
             Width =850
             Height =850
         End
         Begin Image
             BackStyle =0
             OldBorderStyle =0
+            BorderLineStyle =0
             PictureAlignment =2
             Width =1701
             Height =1701
@@ -145,20 +147,23 @@ Begin Form
             FontWeight =400
             ForeColor =-2147483630
             FontName ="MS Sans Serif"
+            BorderLineStyle =0
         End
         Begin CheckBox
             SpecialEffect =2
+            BorderLineStyle =0
             LabelX =230
             LabelY =-30
         End
         Begin TextBox
             SpecialEffect =2
             OldBorderStyle =0
+            BorderLineStyle =0
             Width =1701
             LabelX =-1701
         End
         Begin Section
-            Height =7653
+            Height =7972
             Name ="Detail"
             Begin
                 Begin Rectangle
@@ -166,8 +171,12 @@ Begin Form
                     Left =238
                     Top =1981
                     Width =3335
-                    Height =1245
+                    Height =1650
                     Name ="Box24"
+                    LayoutCachedLeft =238
+                    LayoutCachedTop =1981
+                    LayoutCachedWidth =3573
+                    LayoutCachedHeight =3631
                 End
                 Begin TextBox
                     OverlapFlags =85
@@ -180,6 +189,7 @@ Begin Form
                     ControlSource ="ExportPath"
                     AfterUpdate ="[Event Procedure]"
                     DefaultValue ="\"C:\\SVNRoot\\\""
+
                     Begin
                         Begin Label
                             OverlapFlags =85
@@ -208,13 +218,23 @@ Begin Form
                 Begin CommandButton
                     OverlapFlags =215
                     Left =1995
-                    Top =2850
+                    Top =3240
                     Width =1520
                     Height =340
                     TabIndex =10
                     Name ="cmdRun"
                     Caption ="Export Objects"
                     OnClick ="[Event Procedure]"
+
+                    LayoutCachedLeft =1995
+                    LayoutCachedTop =3240
+                    LayoutCachedWidth =3515
+                    LayoutCachedHeight =3580
+                    WebImagePaddingLeft =2
+                    WebImagePaddingTop =2
+                    WebImagePaddingRight =1
+                    WebImagePaddingBottom =1
+                    Overlaps =1
                 End
                 Begin CheckBox
                     OverlapFlags =93
@@ -226,6 +246,7 @@ Begin Form
                     Name ="chkQueries"
                     ControlSource ="QueriesFlag"
                     DefaultValue ="True"
+
                     Begin
                         Begin Label
                             OverlapFlags =93
@@ -248,6 +269,7 @@ Begin Form
                     Name ="chkForms"
                     ControlSource ="FormsFlag"
                     DefaultValue ="True"
+
                     Begin
                         Begin Label
                             OverlapFlags =93
@@ -270,6 +292,7 @@ Begin Form
                     Name ="chkReports"
                     ControlSource ="ReportsFlag"
                     DefaultValue ="True"
+
                     Begin
                         Begin Label
                             OverlapFlags =93
@@ -292,6 +315,7 @@ Begin Form
                     Name ="chkMacros"
                     ControlSource ="MacrosFlag"
                     DefaultValue ="True"
+
                     Begin
                         Begin Label
                             OverlapFlags =93
@@ -314,6 +338,7 @@ Begin Form
                     Name ="chkModules"
                     ControlSource ="ModulesFlag"
                     DefaultValue ="True"
+
                     Begin
                         Begin Label
                             OverlapFlags =93
@@ -329,13 +354,23 @@ Begin Form
                 Begin CommandButton
                     OverlapFlags =93
                     Left =1995
-                    Top =4125
+                    Top =4515
                     Width =1520
                     Height =340
                     TabIndex =17
                     Name ="btnImport"
                     Caption ="Import Objects"
                     OnClick ="[Event Procedure]"
+
+                    LayoutCachedLeft =1995
+                    LayoutCachedTop =4515
+                    LayoutCachedWidth =3515
+                    LayoutCachedHeight =4855
+                    WebImagePaddingLeft =2
+                    WebImagePaddingTop =2
+                    WebImagePaddingRight =1
+                    WebImagePaddingBottom =1
+                    Overlaps =1
                 End
                 Begin CommandButton
                     OverlapFlags =85
@@ -358,10 +393,13 @@ Begin Form
                         0xadadadadadadadad
                     End
                     ObjectPalette = Begin
-                        0x0003100000000000800000000080000080800000000080008000800000808000 ,
-                        0x80808000c0c0c000ff000000c0c0c000ffff00000000ff00c0c0c00000ffff00 ,
-                        0xffffff0000000000
+                        0x000301000000000000000000
                     End
+
+                    WebImagePaddingLeft =2
+                    WebImagePaddingTop =2
+                    WebImagePaddingRight =1
+                    WebImagePaddingBottom =1
                 End
                 Begin CheckBox
                     OverlapFlags =215
@@ -374,6 +412,7 @@ Begin Form
                     ControlSource ="CommitAfterExport"
                     AfterUpdate ="[Event Procedure]"
                     DefaultValue ="=True"
+
                     Begin
                         Begin Label
                             OverlapFlags =223
@@ -400,15 +439,19 @@ Begin Form
                 Begin Rectangle
                     OverlapFlags =223
                     Left =240
-                    Top =3408
+                    Top =3798
                     Width =3335
                     Height =1155
                     Name ="Box29"
+                    LayoutCachedLeft =240
+                    LayoutCachedTop =3798
+                    LayoutCachedWidth =3575
+                    LayoutCachedHeight =4953
                 End
                 Begin CheckBox
                     OverlapFlags =215
                     Left =3141
-                    Top =3612
+                    Top =4002
                     Width =171
                     Height =170
                     TabIndex =13
@@ -416,15 +459,24 @@ Begin Form
                     ControlSource ="UpdateBeforeImport"
                     AfterUpdate ="[Event Procedure]"
                     DefaultValue ="=True"
+
+                    LayoutCachedLeft =3141
+                    LayoutCachedTop =4002
+                    LayoutCachedWidth =3312
+                    LayoutCachedHeight =4172
                     Begin
                         Begin Label
                             OverlapFlags =223
                             Left =345
-                            Top =3555
+                            Top =3945
                             Width =2385
                             Height =240
                             Name ="lblUpdate"
                             Caption ="Update from SVN before import?"
+                            LayoutCachedLeft =345
+                            LayoutCachedTop =3945
+                            LayoutCachedWidth =2730
+                            LayoutCachedHeight =4185
                         End
                     End
                 End
@@ -432,20 +484,28 @@ Begin Form
                     BackStyle =1
                     OverlapFlags =215
                     Left =405
-                    Top =3285
+                    Top =3675
                     Width =690
                     Height =210
                     FontWeight =700
                     Name ="lblImport"
                     Caption ="Import"
+                    LayoutCachedLeft =405
+                    LayoutCachedTop =3675
+                    LayoutCachedWidth =1095
+                    LayoutCachedHeight =3885
                 End
                 Begin Rectangle
                     OverlapFlags =255
                     Left =3701
                     Top =1981
                     Width =2375
-                    Height =4500
+                    Height =4905
                     Name ="Box33"
+                    LayoutCachedLeft =3701
+                    LayoutCachedTop =1981
+                    LayoutCachedWidth =6076
+                    LayoutCachedHeight =6886
                 End
                 Begin Label
                     BackStyle =1
@@ -468,6 +528,7 @@ Begin Form
                     Name ="chkSelectAllObjects"
                     DefaultValue ="True"
                     OnClick ="[Event Procedure]"
+
                     Begin
                         Begin Label
                             OverlapFlags =247
@@ -483,21 +544,29 @@ Begin Form
                 Begin Rectangle
                     OverlapFlags =93
                     Left =210
-                    Top =4762
+                    Top =5152
                     Width =3335
                     Height =1740
                     Name ="Box37"
+                    LayoutCachedLeft =210
+                    LayoutCachedTop =5152
+                    LayoutCachedWidth =3545
+                    LayoutCachedHeight =6892
                 End
                 Begin Label
                     BackStyle =1
                     OverlapFlags =215
                     Left =375
-                    Top =4650
+                    Top =5040
                     Width =690
                     Height =210
                     FontWeight =700
                     Name ="Label38"
                     Caption ="Status"
+                    LayoutCachedLeft =375
+                    LayoutCachedTop =5040
+                    LayoutCachedWidth =1065
+                    LayoutCachedHeight =5250
                 End
                 Begin TextBox
                     Enabled = NotDefault
@@ -505,7 +574,7 @@ Begin Form
                     SpecialEffect =0
                     OverlapFlags =215
                     Left =1466
-                    Top =4935
+                    Top =5325
                     Width =2021
                     Height =238
                     FontWeight =600
@@ -514,15 +583,24 @@ Begin Form
                     Name ="txtLastImported"
                     ControlSource ="LastImportDate"
                     Format ="Short Date"
+
+                    LayoutCachedLeft =1466
+                    LayoutCachedTop =5325
+                    LayoutCachedWidth =3487
+                    LayoutCachedHeight =5563
                     Begin
                         Begin Label
                             OverlapFlags =215
                             Left =270
-                            Top =4935
+                            Top =5325
                             Width =1095
                             Height =240
                             Name ="lblStatus1"
                             Caption ="Last Imported:"
+                            LayoutCachedLeft =270
+                            LayoutCachedTop =5325
+                            LayoutCachedWidth =1365
+                            LayoutCachedHeight =5565
                         End
                     End
                 End
@@ -533,7 +611,7 @@ Begin Form
                     OverlapFlags =215
                     TextAlign =3
                     Left =2546
-                    Top =5250
+                    Top =5640
                     Width =926
                     Height =238
                     FontWeight =600
@@ -541,15 +619,24 @@ Begin Form
                     BorderColor =8421504
                     Name ="txtLastVersion"
                     ControlSource ="LastCheckoutVersion"
+
+                    LayoutCachedLeft =2546
+                    LayoutCachedTop =5640
+                    LayoutCachedWidth =3472
+                    LayoutCachedHeight =5878
                     Begin
                         Begin Label
                             OverlapFlags =215
                             Left =270
-                            Top =5250
+                            Top =5640
                             Width =2205
                             Height =240
                             Name ="Label42"
                             Caption ="BASE Version in Access:"
+                            LayoutCachedLeft =270
+                            LayoutCachedTop =5640
+                            LayoutCachedWidth =2475
+                            LayoutCachedHeight =5880
                         End
                     End
                 End
@@ -560,22 +647,31 @@ Begin Form
                     OverlapFlags =215
                     TextAlign =3
                     Left =2546
-                    Top =5880
+                    Top =6270
                     Width =926
                     Height =238
                     FontWeight =600
                     TabIndex =26
                     BorderColor =8421504
                     Name ="txtLatestVersion"
+
+                    LayoutCachedLeft =2546
+                    LayoutCachedTop =6270
+                    LayoutCachedWidth =3472
+                    LayoutCachedHeight =6508
                     Begin
                         Begin Label
                             OverlapFlags =215
                             Left =270
-                            Top =5880
+                            Top =6270
                             Width =2205
                             Height =240
                             Name ="lblLatestVersio"
                             Caption ="HEAD Version in Respository:"
+                            LayoutCachedLeft =270
+                            LayoutCachedTop =6270
+                            LayoutCachedWidth =2475
+                            LayoutCachedHeight =6510
                         End
                     End
                 End
@@ -589,6 +685,7 @@ Begin Form
                     Name ="chkTables"
                     ControlSource ="TablesFlag"
                     DefaultValue ="True"
+
                     Begin
                         Begin Label
                             OverlapFlags =247
@@ -611,6 +708,7 @@ Begin Form
                     Name ="chkCmdBars"
                     ControlSource ="ToolbarsFlag"
                     DefaultValue ="True"
+
                     Begin
                         Begin Label
                             OverlapFlags =247
@@ -634,6 +732,7 @@ Begin Form
                     Name ="chkImportExport"
                     ControlSource ="ImExSpecsFlag"
                     DefaultValue ="True"
+
                     Begin
                         Begin Label
                             OverlapFlags =247
@@ -658,6 +757,7 @@ Begin Form
                     TabIndex =24
                     Name ="chkRelationships"
                     ControlSource ="RelationshipsFlag"
+
                     Begin
                         Begin Label
                             OverlapFlags =247
@@ -674,7 +774,7 @@ Begin Form
                 Begin CheckBox
                     OverlapFlags =215
                     Left =2938
-                    Top =6228
+                    Top =6618
                     Width =170
                     Height =170
                     TabIndex =27
@@ -682,15 +782,24 @@ Begin Form
                     ControlSource ="CheckRepoOnSartup"
                     AfterUpdate ="[Event Procedure]"
                     DefaultValue ="=True"
+
+                    LayoutCachedLeft =2938
+                    LayoutCachedTop =6618
+                    LayoutCachedWidth =3108
+                    LayoutCachedHeight =6788
                     Begin
                         Begin Label
                             OverlapFlags =215
                             Left =272
-                            Top =6198
+                            Top =6588
                             Width =2535
                             Height =240
                             Name ="lblCheckRepository"
                             Caption ="Check repository version on startup"
+                            LayoutCachedLeft =272
+                            LayoutCachedTop =6588
+                            LayoutCachedWidth =2807
+                            LayoutCachedHeight =6828
                         End
                     End
                 End
@@ -704,6 +813,7 @@ Begin Form
                     Name ="chkExtras"
                     ControlSource ="ExtrasFlag"
                     DefaultValue ="True"
+
                     Begin
                         Begin Label
                             OverlapFlags =247
@@ -726,6 +836,7 @@ Begin Form
                     Name ="chkReferences"
                     ControlSource ="ReferencesFlag"
                     DefaultValue ="True"
+
                     Begin
                         Begin Label
                             OverlapFlags =247
@@ -742,7 +853,7 @@ Begin Form
                     Enabled = NotDefault
                     OverlapFlags =93
                     Left =2095
-                    Top =6782
+                    Top =7172
                     Width =340
                     Height =328
                     TabIndex =28
@@ -760,38 +871,58 @@ Begin Form
                         0xadadadadadadadad
                     End
                     ObjectPalette = Begin
-                        0x0003100000000000800000000080000080800000000080008000800000808000 ,
-                        0x80808000c0c0c000ff000000c0c0c000ffff00000000ff00c0c0c00000ffff00 ,
-                        0xffffff0000000000
+                        0x000301000000000000000000
                     End
+
+                    LayoutCachedLeft =2095
+                    LayoutCachedTop =7172
+                    LayoutCachedWidth =2435
+                    LayoutCachedHeight =7500
+                    WebImagePaddingLeft =2
+                    WebImagePaddingTop =2
+                    WebImagePaddingRight =1
+                    WebImagePaddingBottom =1
+                    Overlaps =1
                 End
                 Begin Label
                     OverlapFlags =93
                     Left =395
-                    Top =6839
+                    Top =7229
                     Width =1635
                     Height =210
                     Name ="lblCompact"
                     Caption ="Compact Database?"
+                    LayoutCachedLeft =395
+                    LayoutCachedTop =7229
+                    LayoutCachedWidth =2030
+                    LayoutCachedHeight =7439
                 End
                 Begin Rectangle
                     OverlapFlags =223
                     Left =225
-                    Top =6682
+                    Top =7072
                     Width =5840
                     Height =870
                     Name ="Box62"
+                    LayoutCachedLeft =225
+                    LayoutCachedTop =7072
+                    LayoutCachedWidth =6065
+                    LayoutCachedHeight =7942
                 End
                 Begin Label
                     BackStyle =1
                     OverlapFlags =215
                     Left =395
-                    Top =6555
+                    Top =6945
                     Width =1140
                     Height =210
                     FontWeight =700
                     Name ="lblTool"
                     Caption ="Other Tools"
+                    LayoutCachedLeft =395
+                    LayoutCachedTop =6945
+                    LayoutCachedWidth =1535
+                    LayoutCachedHeight =7155
                 End
                 Begin TextBox
                     SpecialEffect =0
@@ -799,28 +930,37 @@ Begin Form
                     OverlapFlags =215
                     BackStyle =0
                     Left =3627
-                    Top =6782
+                    Top =7172
                     Width =2324
                     Height =227
                     TabIndex =29
                     BorderColor =8421504
                     Name ="txtDBFile"
+
+                    LayoutCachedLeft =3627
+                    LayoutCachedTop =7172
+                    LayoutCachedWidth =5951
+                    LayoutCachedHeight =7399
                     Begin
                         Begin Label
                             OverlapFlags =215
                             Left =2890
-                            Top =6782
+                            Top =7172
                             Width =615
                             Height =240
                             Name ="Label65"
                             Caption ="DB Size:"
+                            LayoutCachedLeft =2890
+                            LayoutCachedTop =7172
+                            LayoutCachedWidth =3505
+                            LayoutCachedHeight =7412
                         End
                     End
                 End
                 Begin CommandButton
                     OverlapFlags =215
                     Left =2090
-                    Top =7140
+                    Top =7530
                     Width =340
                     Height =328
                     TabIndex =30
@@ -838,19 +978,31 @@ Begin Form
                         0xadadadadadadadad
                     End
                     ObjectPalette = Begin
-                        0x0003100000000000800000000080000080800000000080008000800000808000 ,
-                        0x80808000c0c0c000ff000000c0c0c000ffff00000000ff00c0c0c00000ffff00 ,
-                        0xffffff0000000000
+                        0x000301000000000000000000
                     End
+
+                    LayoutCachedLeft =2090
+                    LayoutCachedTop =7530
+                    LayoutCachedWidth =2430
+                    LayoutCachedHeight =7858
+                    WebImagePaddingLeft =2
+                    WebImagePaddingTop =2
+                    WebImagePaddingRight =1
+                    WebImagePaddingBottom =1
+                    Overlaps =1
                 End
                 Begin Label
                     OverlapFlags =215
                     Left =390
-                    Top =7197
+                    Top =7587
                     Width =1635
                     Height =210
                     Name ="Label69"
                     Caption ="Repair Printer Names"
+                    LayoutCachedLeft =390
+                    LayoutCachedTop =7587
+                    LayoutCachedWidth =2025
+                    LayoutCachedHeight =7797
                 End
                 Begin TextBox
                     Enabled = NotDefault
@@ -859,22 +1011,31 @@ Begin Form
                     OverlapFlags =215
                     TextAlign =3
                     Left =2546
-                    Top =5565
+                    Top =5955
                     Width =926
                     Height =238
                     FontWeight =600
                     TabIndex =25
                     BorderColor =8421504
                     Name ="txtFolderVersion"
+
+                    LayoutCachedLeft =2546
+                    LayoutCachedTop =5955
+                    LayoutCachedWidth =3472
+                    LayoutCachedHeight =6193
                     Begin
                         Begin Label
                             OverlapFlags =215
                             Left =270
-                            Top =5565
+                            Top =5955
                             Width =2205
                             Height =240
                             Name ="Label71"
                             Caption ="BASE Version in SVN Folder:"
+                            LayoutCachedLeft =270
+                            LayoutCachedTop =5955
+                            LayoutCachedWidth =2475
+                            LayoutCachedHeight =6195
                         End
                     End
                 End
@@ -894,6 +1055,7 @@ Begin Form
                     BorderColor =8421504
                     ForeColor =12615680
                     Name ="txtSvnUrl"
+
                 End
                 Begin CommandButton
                     OverlapFlags =85
@@ -915,13 +1077,16 @@ Begin Form
                         0xadadadadadadadad
                     End
                     ObjectPalette = Begin
-                        0x0003100000000000800000000080000080800000000080008000800000808000 ,
-                        0x80808000c0c0c000ff000000c0c0c000ffff00000000ff00c0c0c00000ffff00 ,
-                        0xffffff0000000000
+                        0x000301000000000000000000
                     End
                     GUID = Begin
                         0xa47e8cf1809dd24e92b78d63a4f4eb9f
                     End
+
+                    WebImagePaddingLeft =2
+                    WebImagePaddingTop =2
+                    WebImagePaddingRight =1
+                    WebImagePaddingBottom =1
                 End
                 Begin Label
                     OverlapFlags =85
@@ -942,7 +1107,7 @@ Begin Form
                     Height =962
                     Name ="Image6"
                     PictureData = Begin
-                        0x0e000000940c46e8010000006c0000000000000000000000520000003a000000 ,
+                        0x0e00000000000000010000006c0000000000000000000000520000003a000000 ,
                         0x0000000000000000180900009d06000020454d46000001006487000011000000 ,
                         0x01000000000000000000000000000000900600001a040000d60100002c010000 ,
                         0x000000000000000000000000f02b0700e093040046000000b8430000ac430000 ,
@@ -2027,15 +2192,17 @@ Begin Form
                         0x0c0000000f0000804b0000001000000000000000050000000e00000014000000 ,
                         0x000000001000000014000000
                     End
-                    Picture ="C:\\Documents and Settings\\Mike\\My Documents\\My Pictures\\subversion-logo.PNG"
+                    Picture ="subversion-logo.PNG"
                     GUID = Begin
                         0xa961e7550492d74686ac48ae557e5070
                     End
+
+                    TabIndex =33
                 End
                 Begin CheckBox
                     OverlapFlags =215
                     Left =5751
-                    Top =7264
+                    Top =7654
                     Width =170
                     Height =170
                     TabIndex =31
@@ -2044,11 +2211,16 @@ Begin Form
                     GUID = Begin
                         0x4fe0e5285bd96f46a9a1784c00b69596
                     End
+
+                    LayoutCachedLeft =5751
+                    LayoutCachedTop =7654
+                    LayoutCachedWidth =5921
+                    LayoutCachedHeight =7824
                     Begin
                         Begin Label
                             OverlapFlags =215
                             Left =4050
-                            Top =7208
+                            Top =7598
                             Width =1590
                             Height =240
                             Name ="Label81"
@@ -2056,6 +2228,10 @@ Begin Form
                             GUID = Begin
                                 0xe43a4967611bae4ca68f44ed904d1fc2
                             End
+                            LayoutCachedLeft =4050
+                            LayoutCachedTop =7598
+                            LayoutCachedWidth =5640
+                            LayoutCachedHeight =7838
                         End
                     End
                 End
@@ -2074,6 +2250,7 @@ Begin Form
                     GUID = Begin
                         0x6cd96ee08ab3a64c884ce79be152aaac
                     End
+
                     Begin
                         Begin Label
                             OverlapFlags =223
@@ -2092,7 +2269,7 @@ Begin Form
                 Begin CheckBox
                     OverlapFlags =215
                     Left =3141
-                    Top =3852
+                    Top =4242
                     Width =171
                     Height =170
                     TabIndex =15
@@ -2102,11 +2279,16 @@ Begin Form
                     GUID = Begin
                         0x668b492f627992469a6ae5bd79faf129
                     End
+
+                    LayoutCachedLeft =3141
+                    LayoutCachedTop =4242
+                    LayoutCachedWidth =3312
+                    LayoutCachedHeight =4412
                     Begin
                         Begin Label
                             OverlapFlags =215
                             Left =480
-                            Top =3795
+                            Top =4185
                             Width =2535
                             Height =240
                             Name ="Label89"
@@ -2114,6 +2296,10 @@ Begin Form
                             GUID = Begin
                                 0xe6ca32001f59144c86a38cc027be55d4
                             End
+                            LayoutCachedLeft =480
+                            LayoutCachedTop =4185
+                            LayoutCachedWidth =3015
+                            LayoutCachedHeight =4425
                         End
                     End
                 End
@@ -2130,6 +2316,7 @@ Begin Form
                     GUID = Begin
                         0xdf6986384e06fd438543b5cca0ef086c
                     End
+
                     Begin
                         Begin Label
                             OverlapFlags =215
@@ -2142,6 +2329,43 @@ Begin Form
                             GUID = Begin
                                 0x2ed165d4dd619248b871843ccb7a1163
                             End
+                        End
+                    End
+                End
+                Begin CheckBox
+                    OverlapFlags =215
+                    Left =3156
+                    Top =2952
+                    Width =171
+                    Height =170
+                    TabIndex =32
+                    Name ="chkOutputUTF8"
+                    ControlSource ="OutputUTF8"
+                    DefaultValue ="=True"
+                    GUID = Begin
+                        0x2043d428c314ff47adc10df8533562ab
+                    End
+
+                    LayoutCachedLeft =3156
+                    LayoutCachedTop =2952
+                    LayoutCachedWidth =3327
+                    LayoutCachedHeight =3122
+                    Begin
+                        Begin Label
+                            OverlapFlags =215
+                            Left =345
+                            Top =2895
+                            Width =2565
+                            Height =240
+                            Name ="Label94"
+                            Caption ="UTF8 Encoding (rather than UCS2)"
+                            GUID = Begin
+                                0x2c7198c27e35ad48aaef82670f582a94
+                            End
+                            LayoutCachedLeft =345
+                            LayoutCachedTop =2895
+                            LayoutCachedWidth =2910
+                            LayoutCachedHeight =3135
                         End
                     End
                 End
@@ -2278,7 +2502,7 @@ Private Sub Form_Load()
   Me.txtOutputLocation.SetFocus
 
   DoCmd.Hourglass True
-  strRecordSource = "SELECT ExportPath, CommitAfterExport, UpdateBeforeImport, QueriesFlag, FormsFlag, ReportsFlag, MacrosFlag, ModulesFlag, TablesFlag, ToolbarsFlag, ExtrasFlag, ReferencesFlag, ImExSpecsFlag, RelationshipsFlag, LastImportDate, LastCheckoutVersion, CheckRepoOnSartup, ShowCommitWindow, ShowUpdateWindow FROM MSysSCCPrefs IN '" & CurrentDb().Name & "'"
+  strRecordSource = "SELECT ExportPath, CommitAfterExport, UpdateBeforeImport, QueriesFlag, FormsFlag, ReportsFlag, MacrosFlag, ModulesFlag, TablesFlag, ToolbarsFlag, ExtrasFlag, ReferencesFlag, ImExSpecsFlag, RelationshipsFlag, LastImportDate, LastCheckoutVersion, CheckRepoOnSartup, ShowCommitWindow, ShowUpdateWindow, OutputUTF8 FROM MSysSCCPrefs IN '" & CurrentDb().Name & "'"
 
   Me.RecordSource = strRecordSource
 

--- a/Modules/asCreateTables.ACM
+++ b/Modules/asCreateTables.ACM
@@ -40,6 +40,10 @@ Public Sub CreateLocalSCCTables()
     Set fd = AddField(db.TableDefs("MSysSCCPrefs"), "ShowUpdateWindow", dbBoolean, 0, "Whether to show the update window, or auto close it", , , , , , , , True)
   End If
   
+  If InFields(db.TableDefs("MSysSCCPrefs").Fields, "OutputUTF8") = False Then
+    Set fd = AddField(db.TableDefs("MSysSCCPrefs"), "OutputUTF8", dbBoolean, 0, "Whether output for Forms, Reports, Queries and Macros should be in UTF8 rather than UCS2", , , , , , , , True)
+  End If
+  
   db.Close: Set db = Nothing
 End Sub
 
@@ -188,6 +192,7 @@ Private Function CreateSCCPrefsTable(db As DAO.Database)
   Set fd = AddField(td, "CheckRepoOnSartup", dbBoolean, 0, "Whether to check  the repository version on startup", , , , , , , , True)
   Set fd = AddField(td, "ShowCommitWindow", dbBoolean, 0, "Whether to show the commit window, or auto close it", , , , , , , , True)
   Set fd = AddField(td, "ShowUpdateWindow", dbBoolean, 0, "Whether to show the update window, or auto close it", , , , , , , , True)
+  Set fd = AddField(td, "OutputUTF8", dbBoolean, 0, "Whether output for Forms, Reports, Queries and Macros should be in UTF8 rather than UCS2", , , , , , , , True)
   td.Fields.Delete "Temp"
   
   strSQL = "INSERT INTO [MSysSCCPrefs] (ExportPath) VALUES ('" & CurrentDbDir() & "')"

--- a/Modules/modExtendSaveAsText.ACM
+++ b/Modules/modExtendSaveAsText.ACM
@@ -47,6 +47,7 @@ Private Declare Sub CopyMemory Lib "kernel32" Alias "RtlMoveMemory" (ByVal Desti
 
 Public Sub SaveAsText(objType As asObjectType, objName As String, strFilename As String)
   Dim Ignores(7) As Ignore
+  Dim blnSaveAsUTF8 As Boolean
 
   Ignores(0).bytsStart = "GUID = Begin" & vbCrLf
   Ignores(0).bytsEnd = "End" & vbCrLf
@@ -65,17 +66,47 @@ Public Sub SaveAsText(objType As asObjectType, objName As String, strFilename As
   Ignores(7).bytsStart = "NameMap = Begin" & vbCrLf
   Ignores(7).bytsEnd = "End" & vbCrLf
   
+  ' work out whether we need to convert the file to UTF8
+  ' initially set to the user selection
+  blnSaveAsUTF8 = Forms("Access SVN - Options").chkOutputUTF8
+  ' For Forms, Report, Macros and Queries the output from the built in SaveAsText is in the 2 byte UCS2 format
+  ' on later versions of MS Access, otherwise it is in ANSI
+  ' If we already have this file in the repository and it is in UTF-8 we should save it as UTF-8 anyway
+  Select Case objType
+    Case asObjectType.acForm, asObjectType.acReport, asObjectType.acQuery, asObjectType.acMacro
+      If FileExists(strFilename) Then
+        If IsUTF8(strFilename) Then
+          ' Fileis already in the repository and it's in UTF8 so save in that format now overriding user selection
+          blnSaveAsUTF8 = True
+        End If
+      End If
+  End Select
+      
   Select Case objType
     Case asObjectType.acForm, asObjectType.acReport
       Application.SaveAsText objType, objName, strFilename & ".tmp"
-      If Not CleanFormReportFile(strFilename & ".tmp", strFilename, Ignores) Then
-        MsgBox "Something went wrong cleaning the file for " & objName & "."
+      If IsUCS2(strFilename & ".tmp") Then
+        If CleanFormReportFile(strFilename & ".tmp", strFilename, Ignores) Then
+          If blnSaveAsUTF8 And IsUCS2(strFilename) Then
+            If Not ConvFileUCS2_to_UTF8(strFilename) Then 'convert file to UTF8
+              MsgBox "Unable to convert '" & objName & "' to UTF-8 encoding. Beware when committing."
+            End If
+          End If
+        Else
+          MsgBox "Something went wrong cleaning the file for " & objName & "."
+        End If
+      Else
+        ' This version of Access doesn't produce UCS2 output
+        Name strFilename & ".tmp" As strFilename
       End If
       If FileExists(strFilename & ".tmp") Then Kill strFilename & ".tmp"
-      If Forms("Access SVN - Options").chkOutputUTF8 And IsUCS2(strFilename) Then ConvFileUCS2_to_UTF8 strFilename 'convert file to UTF8
     Case asObjectType.acQuery, asObjectType.acMacro
       Application.SaveAsText objType, objName, strFilename
-      If Forms("Access SVN - Options").chkOutputUTF8 And IsUCS2(strFilename) Then ConvFileUCS2_to_UTF8 strFilename 'convert file to UTF8
+      If blnSaveAsUTF8 And IsUCS2(strFilename) Then
+        If Not ConvFileUCS2_to_UTF8(strFilename) Then 'convert file to UTF8
+          MsgBox "Unable to convert '" & objName & "' to UTF-8 encoding. Beware when committing."
+        End If
+      End If
     Case asObjectType.acModule
       Application.SaveAsText objType, objName, strFilename ' no conversion needed - modules are output as ANSI
     Case asObjectType.acTable, asObjectType.acIMEXSpecs
@@ -104,32 +135,41 @@ Public Sub LoadFromText(objType As asObjectType, ByVal objName As String, strFil
         strErr = "The Form '" & objName & "' is already open. Inserted as " & objName & "-svntmp. Please rename after import"
         objName = objName & "-svntmp"
       End If
-      If IsUCS2(strFilename) Then
-        Application.LoadFromText objType, objName, strFilename
+      If IsUTF8(strFilename) Then
+        If ConvFileUTF8_to_UCS2(strFilename, strFilename & ".tmp") Then
+          Application.LoadFromText objType, objName, strFilename & ".tmp"
+          Kill strFilename & ".tmp"
+        Else
+          strErr = "Unable to Convert '" & strFilename & "' from UTF-8 encoding to UCS2 so it has not imported. Please review after import."
+        End If
       Else
-        ConvFileUTF8_to_UCS2 strFilename, strFilename & ".tmp"
-        Application.LoadFromText objType, objName, strFilename & ".tmp"
-        Kill strFilename & ".tmp"
+        Application.LoadFromText objType, objName, strFilename
       End If
     Case asObjectType.acReport, asObjectType.acMacro
-      If IsUCS2(strFilename) Then
-        Application.LoadFromText objType, objName, strFilename
+      If IsUTF8(strFilename) Then
+        If ConvFileUTF8_to_UCS2(strFilename, strFilename & ".tmp") Then
+          Application.LoadFromText objType, objName, strFilename & ".tmp"
+          Kill strFilename & ".tmp"
+        Else
+          strErr = "Unable to Convert '" & strFilename & "' from UTF-8 encoding to UCS2 so it has not imported. Please review after import."
+        End If
       Else
-        ConvFileUTF8_to_UCS2 strFilename, strFilename & ".tmp"
-        Application.LoadFromText objType, objName, strFilename & ".tmp"
-        Kill strFilename & ".tmp"
+        Application.LoadFromText objType, objName, strFilename
       End If
     Case asObjectType.acModule
       Application.LoadFromText objType, objName, strFilename
     Case asObjectType.acTable, asObjectType.acIMEXSpecs
       LoadTableFromText objName, strFilename
     Case asObjectType.acQuery
-      If IsUCS2(strFilename) Then
-        LoadQueryFromText objName, strFilename
+      If IsUTF8(strFilename) Then
+        If ConvFileUTF8_to_UCS2(strFilename, strFilename & ".tmp") Then
+          LoadQueryFromText objName, strFilename & ".tmp"
+          Kill strFilename & ".tmp"
+        Else
+          strErr = "Unable to Convert '" & strFilename & "' from UTF-8 encoding to UCS2 so it has not imported. Please review after import."
+        End If
       Else
-        ConvFileUTF8_to_UCS2 strFilename, strFilename & ".tmp"
-        LoadQueryFromText objName, strFilename & ".tmp"
-        Kill strFilename & ".tmp"
+        LoadQueryFromText objName, strFilename
       End If
     Case asObjectType.acToolbar
       strCatchErr = LoadCommandBarFromText(objName, strFilename)

--- a/Modules/modExtendSaveAsText.ACM
+++ b/Modules/modExtendSaveAsText.ACM
@@ -72,8 +72,12 @@ Public Sub SaveAsText(objType As asObjectType, objName As String, strFilename As
         MsgBox "Something went wrong cleaning the file for " & objName & "."
       End If
       If FileExists(strFilename & ".tmp") Then Kill strFilename & ".tmp"
-    Case asObjectType.acQuery, asObjectType.acMacro, asObjectType.acModule
+      If Forms("Access SVN - Options").chkOutputUTF8 And IsUCS2(strFilename) Then ConvFileUCS2_to_UTF8 strFilename 'convert file to UTF8
+    Case asObjectType.acQuery, asObjectType.acMacro
       Application.SaveAsText objType, objName, strFilename
+      If Forms("Access SVN - Options").chkOutputUTF8 And IsUCS2(strFilename) Then ConvFileUCS2_to_UTF8 strFilename 'convert file to UTF8
+    Case asObjectType.acModule
+      Application.SaveAsText objType, objName, strFilename ' no conversion needed - modules are output as ANSI
     Case asObjectType.acTable, asObjectType.acIMEXSpecs
       SaveTableAsText objName, strFilename
     Case asObjectType.acToolbar
@@ -89,6 +93,10 @@ End Sub
 Public Sub LoadFromText(objType As asObjectType, ByVal objName As String, strFilename As String, Optional strErr As String)
   Dim strCatchErr As String
   
+  ' Forms, Reports, Queries and Reports are produced and read by Access from UCS2 ( 2 byte ) encoded files
+  ' These are re-encoded to UTF-8 on saving so that all SVN tools work
+  ' Due to the historic files not having been converted we need to check whether these files are in UTF8 or UCS2 format and convert if required
+  
   Select Case objType
     Case asObjectType.acForm
       ' This is needed for when importing the SVN Tool from SVN using the SVN Tool!!!!!????
@@ -96,13 +104,33 @@ Public Sub LoadFromText(objType As asObjectType, ByVal objName As String, strFil
         strErr = "The Form '" & objName & "' is already open. Inserted as " & objName & "-svntmp. Please rename after import"
         objName = objName & "-svntmp"
       End If
-      Application.LoadFromText acForm, objName, strFilename
-    Case asObjectType.acReport, asObjectType.acMacro, asObjectType.acModule
+      If IsUCS2(strFilename) Then
+        Application.LoadFromText objType, objName, strFilename
+      Else
+        ConvFileUTF8_to_UCS2 strFilename, strFilename & ".tmp"
+        Application.LoadFromText objType, objName, strFilename & ".tmp"
+        Kill strFilename & ".tmp"
+      End If
+    Case asObjectType.acReport, asObjectType.acMacro
+      If IsUCS2(strFilename) Then
+        Application.LoadFromText objType, objName, strFilename
+      Else
+        ConvFileUTF8_to_UCS2 strFilename, strFilename & ".tmp"
+        Application.LoadFromText objType, objName, strFilename & ".tmp"
+        Kill strFilename & ".tmp"
+      End If
+    Case asObjectType.acModule
       Application.LoadFromText objType, objName, strFilename
     Case asObjectType.acTable, asObjectType.acIMEXSpecs
       LoadTableFromText objName, strFilename
     Case asObjectType.acQuery
-      LoadQueryFromText objName, strFilename
+      If IsUCS2(strFilename) Then
+        LoadQueryFromText objName, strFilename
+      Else
+        ConvFileUTF8_to_UCS2 strFilename, strFilename & ".tmp"
+        LoadQueryFromText objName, strFilename & ".tmp"
+        Kill strFilename & ".tmp"
+      End If
     Case asObjectType.acToolbar
       strCatchErr = LoadCommandBarFromText(objName, strFilename)
       If strCatchErr <> "" Then

--- a/Modules/modFileEncoding.ACM
+++ b/Modules/modFileEncoding.ACM
@@ -12,10 +12,32 @@ Function IsUCS2(strFilename As String) As Boolean
     ' load the file into the bytsFile array
     f = FreeFile()
     Open strFilename For Binary Access Read As #f
-    ReDim byts(2)
-    Get #f, 1, byts()
+    If LOF(f) >= 2 Then
+      ReDim byts(1)
+      Get #f, 1, byts()
+      IsUCS2 = ((byts(0) = 255) And (byts(1) = 254)) ' &HFF and &HFE
+    End If
     Close #f
-    IsUCS2 = ((byts(0) = 255) And (byts(1) = 254))
+  End If
+End Function
+
+Function IsUTF8(strFilename As String) As Boolean
+  ' Returns true if the file specified is in UTF8 format
+  ' NB this needs the BOM to be present in order to identify as UTF8 - this is not strictly in accordance with
+  ' UTF8 specififcations, but is the same as many Windows implementations
+  Dim f As Long
+  Dim byts() As Byte
+  
+  If FileExists(strFilename) Then
+    ' load the file into the bytsFile array
+    f = FreeFile()
+    Open strFilename For Binary Access Read As #f
+    If LOF(f) >= 3 Then
+      ReDim byts(2)
+      Get #f, 1, byts()
+      IsUTF8 = ((byts(0) = 239) And (byts(1) = 187) And (byts(1) = 191)) '&HEF, &HBB, &HBF
+    End If
+    Close #f
   End If
 End Function
 
@@ -103,17 +125,12 @@ Function UCS2_to_UTF8(bytsUCS2() As Byte, ByRef bytsUTF8() As Byte) As Boolean
   If bytsUCS2(LBound(bytsUCS2)) <> 255 Or bytsUCS2(LBound(bytsUCS2) + 1) <> 254 Then Exit Function '255 = &HFF, 254 = &HFE
   
   ' Redim bytsUTF8 to the maximum it can be ( max 3 bytes per character )
-  ' ignore header of UCS2 (2 bytes) then for each 2 bytes in UCS2 need potentially 3 bytes in UTF8
-  If lenUCS2 = 2 Then
-    ' we need to return an empty array
-    Erase bytsUTF8
-    UCS2_to_UTF8 = True
-    Exit Function
-  End If
+  ' for each 2 bytes in UCS2 need potentially 3 bytes in UTF8
+  ReDim bytsUTF8(lenUCS2 * 3 / 2 - 1)
   
-  ReDim bytsUTF8((lenUCS2 - 2) * 3 / 2 - 1)
+  b = 0
   
-  For i = LBound(bytsUCS2) + 2 To UBound(bytsUCS2) Step 2
+  For i = LBound(bytsUCS2) To UBound(bytsUCS2) Step 2
     CopyMemory VarPtr(CP_UCS2(0)), VarPtr(bytsUCS2(i)), 2 ' Copy CodePoint into CP array
     If Not UCS2CP_to_UTF8CP(CP_UCS2, CP_UTF8) Then Exit Function
     CopyMemory VarPtr(bytsUTF8(b)), VarPtr(CP_UTF8(0)), UBound(CP_UTF8) + 1
@@ -139,20 +156,23 @@ Function UTF8_to_UCS2(bytsUTF8() As Byte, ByRef bytsUCS2() As Byte) As Boolean
   
   lenUTF8 = UBound(bytsUTF8) - LBound(bytsUTF8) + 1
   
-  ' Redim bytsUCS2 to the maximum it can be (header plus 2 bytes for each byte in UTF8
-  ReDim bytsUCS2(2 + lenUTF8 * 2)
+  ' Check that the length of the UTF8 array is at least 3 bytes
+  If lenUTF8 < 3 Then Exit Function
   
-  ' Write the BOM
-  bytsUCS2(0) = 255
-  bytsUCS2(1) = 254
-  b = 2
+  ' Check that the supplied array has the correct Byte Order Mark (BOM)
+  If bytsUTF8(LBound(bytsUTF8)) <> 239 Or bytsUTF8(LBound(bytsUTF8) + 1) <> 187 Or bytsUTF8(LBound(bytsUTF8) + 2) <> 191 Then Exit Function '239 = &HEF, 187 = &HBB, 191 = &HBF
+  
+  ' Redim bytsUCS2 to the maximum it can be (2 bytes for each byte in UTF8)
+  ReDim bytsUCS2(lenUTF8 * 2 - 1)
+  
+  b = 0
   
   For i = LBound(bytsUTF8) To UBound(bytsUTF8)
-    j = UTF8CP_to_UCS2CP(bytsUTF8, i, CP_UCS2)
+    j = UTF8CP_to_UCS2CP(bytsUTF8, i, CP_UCS2) 'j represents the length of the UTF8 character found (in bytes)
     If j = 0 Then Exit Function
     CopyMemory VarPtr(bytsUCS2(b)), VarPtr(CP_UCS2(0)), 2
     b = b + 2
-    i = i + j - 1
+    i = i + j - 1 ' if UTF8 was more than 1 byte, skip forwards
   Next
   
   ReDim Preserve bytsUCS2(b - 1)
@@ -160,8 +180,31 @@ Function UTF8_to_UCS2(bytsUTF8() As Byte, ByRef bytsUCS2() As Byte) As Boolean
   
 End Function
 
-Private Function UTF8CP_to_UCS2CP(bytsUTF8() As Byte, P As Long, bytsUCS2() As Byte) As Long
-  ' This function takes a UTF8 byte array and converts the codepoint at location p into a UCS2 byte array (length 2)
+' The 2 Functions UTF8CP_to_UCS2CP and UCS2CP_to_UTF8CP convert individual Codepoints (characters) to/from the 2 encodings
+' The format of UTF8 is laid out below (extract from wikipedia)
+'
+' Since the restriction of the Unicode code-space to 21-bit values in 2003, UTF-8 is defined to encode code points in one to
+' four bytes, depending on the number of significant bits in the numerical value of the code point. The following table shows
+' the structure of the encoding. The x characters are replaced by the bits of the code point. If the number of significant
+' bits is no more than seven, the first line applies; if no more than 11 bits, the second line applies, and so on.
+'
+' Number    Bits for    First       Last           Byte 1    Byte 2    Byte 3    Byte 4
+' of bytes  code point  code point  code point
+'    1          7         U+0000      U+007F      0xxxxxxx
+'    2         11         U+0080      U+07FF      110xxxxx  10xxxxxx
+'    3         16         U+0800      U+FFFF      1110xxxx  10xxxxxx  10xxxxxx
+'    4         21         U+10000     U+10FFFF    11110xxx  10xxxxxx  10xxxxxx  10xxxxxx
+'
+' MS Access always converts Hex literals into the smallest integer they will fit into before assigning to a variable
+' and also has no concept of unsigned integers.
+' Therefore:
+'   lngExample = &HFFFF
+' will return -1 rather than 65535 as would be expected (it is first converted to an Integer (16 bit)
+' before being assigned to the long.
+' To ensure this doesn't mess up our code we use decimal notation but comment where appropriate with the Hex or Binary equivalent
+
+Private Function UTF8CP_to_UCS2CP(bytsUTF8() As Byte, lngPosn As Long, bytsUCS2() As Byte) As Long
+  ' This function takes a UTF8 byte array and converts the codepoint at location lngPosn into a UCS2 byte array (length 2)
   ' In the event of an error this function returns zero, otherwise it returns the number
   ' of bytes which were used to encode the UTF8 character
   
@@ -169,38 +212,38 @@ Private Function UTF8CP_to_UCS2CP(bytsUTF8() As Byte, P As Long, bytsUCS2() As B
   
   UTF8CP_to_UCS2CP = 0 ' intitally set to zero (fail)
   
-  If P > UBound(bytsUTF8) Then Exit Function
-  If P < LBound(bytsUTF8) Then Exit Function
+  If lngPosn > UBound(bytsUTF8) Then Exit Function
+  If lngPosn < LBound(bytsUTF8) Then Exit Function
   
   ReDim bytsUCS2(1) ' always 2 bytes
   
-  If (bytsUTF8(P) And 128) = 0 Then '128 = 1000 0000 'this byte is 0xxx xxxx
+  If (bytsUTF8(lngPosn) And 128) = 0 Then '128 = 1000 0000 'this byte is 0xxx xxxx
     ' We have a single byte UTF8
-    bytsUCS2(0) = bytsUTF8(P)
+    bytsUCS2(0) = bytsUTF8(lngPosn)
     bytsUCS2(1) = 0
     UTF8CP_to_UCS2CP = 1
-  ElseIf (bytsUTF8(P) And 224) = 192 Then  '224 = 1110 0000, 192 = 1100 0000 'this byte is 110x xxxx
-    If UBound(bytsUTF8) < P + 1 Then Exit Function 'check we have enough bytes left
-    If (bytsUTF8(P + 1) And 192) <> 128 Then Exit Function '192 = 1100 0000, 128 = 1000 0000 2nd byte must be 10xx xxxx
+  ElseIf (bytsUTF8(lngPosn) And 224) = 192 Then  '224 = 1110 0000, 192 = 1100 0000 'this byte is 110x xxxx
+    If UBound(bytsUTF8) < lngPosn + 1 Then Exit Function 'check we have enough bytes left
+    If (bytsUTF8(lngPosn + 1) And 192) <> 128 Then Exit Function '192 = 1100 0000, 128 = 1000 0000 2nd byte must be 10xx xxxx
     ' We have a valid 2 byte UTF8
-    c = bit16ShiftR((bytsUTF8(P) And 31), -6) '31 = 0001 1111
-    c = c Or (bytsUTF8(P + 1) And 63) '63 = 0011 1111
+    c = bit16ShiftL((bytsUTF8(lngPosn) And 31), 6) '31 = 0001 1111
+    c = c Or (bytsUTF8(lngPosn + 1) And 63) '63 = 0011 1111
     bytsUCS2(0) = c And 255 '255 = 1111 1111  least significant byte
     bytsUCS2(1) = bit16ShiftR(c, 8) ' most significant Byte
     UTF8CP_to_UCS2CP = 2
-  ElseIf (bytsUTF8(P) And 240) = 224 Then '240 = 1111 0000, 224 = 1110 0000 'this byte is 1110 xxxx
-    If UBound(bytsUTF8) < P + 2 Then Exit Function 'check we have enough bytes left
-    If (bytsUTF8(P + 1) And 192) <> 128 Then Exit Function '2nd byte must be 10xx xxxx
-    If (bytsUTF8(P + 2) And 192) <> 128 Then Exit Function '3rd byte must be 10xx xxxx
+  ElseIf (bytsUTF8(lngPosn) And 240) = 224 Then '240 = 1111 0000, 224 = 1110 0000 'this byte is 1110 xxxx
+    If UBound(bytsUTF8) < lngPosn + 2 Then Exit Function 'check we have enough bytes left
+    If (bytsUTF8(lngPosn + 1) And 192) <> 128 Then Exit Function '2nd byte must be 10xx xxxx
+    If (bytsUTF8(lngPosn + 2) And 192) <> 128 Then Exit Function '3rd byte must be 10xx xxxx
     ' We have a valid 3 byte UTF8
-    c = bit16ShiftR((bytsUTF8(P) And 15), -12) '15 = 0000 1111
-    c = c Or bit16ShiftR((bytsUTF8(P + 1) And 63), -6) '63 = 0011 1111
-    c = c Or (bytsUTF8(P + 2) And 63) '63 = 0011 1111
+    c = bit16ShiftL((bytsUTF8(lngPosn) And 15), 12) '15 = 0000 1111
+    c = c Or bit16ShiftL((bytsUTF8(lngPosn + 1) And 63), 6) '63 = 0011 1111
+    c = c Or (bytsUTF8(lngPosn + 2) And 63)    '63 = 0011 1111
     bytsUCS2(0) = c And 255 '255 = 1111 1111  least significant byte
     bytsUCS2(1) = bit16ShiftR(c, 8) ' most significant Byte
     UTF8CP_to_UCS2CP = 3
   Else
-    ' we cannot deal with 4 byte UTF8 so we get an error
+    ' we cannot deal with 4 byte UTF8 (it cannot be represented in 2 Bytes) so we return an error
     Exit Function
   End If
     
@@ -209,38 +252,41 @@ End Function
 Private Function UCS2CP_to_UTF8CP(bytsUCS2() As Byte, bytsUTF8() As Byte) As Boolean
   ' This function takes a 2 byte zero based array encoded in UCS2 and returns a 1 to 3 byte array encoded in UTF8
   
-  Dim i As Long ' this is used to represent the character we have
-  Dim j As Long
+  Dim lngCodePoint As Long ' this is used to represent the character we have
   
   UCS2CP_to_UTF8CP = False ' intially set return value to be false
   
   If LBound(bytsUCS2) <> 0 Then Exit Function
   If UBound(bytsUCS2) <> 1 Then Exit Function
   
-  i = bytsUCS2(1) * 256 + bytsUCS2(0) ' Little Endian
+  lngCodePoint = CLng(bytsUCS2(1)) * 256 + CLng(bytsUCS2(0)) ' Little Endian
   
-  If i < 128 Then '128 = &H80
+  If lngCodePoint < 128 Then '128 = &H80
     ' encoded in 1 byte in UTF8
     ReDim bytsUTF8(0)
-    bytsUTF8(0) = i
+    bytsUTF8(0) = lngCodePoint
     UCS2CP_to_UTF8CP = True
-  ElseIf i < 2048 Then '2048 = &H0800
+  ElseIf lngCodePoint < 2048 Then '2048 = &H0800
     ' encoded in 2 bytes in UTF8
     ReDim bytsUTF8(1)
-    bytsUTF8(1) = (i And 63) Or 128 ' 63 = 00111111, 128 = 10000000
-    i = bit16ShiftR(i, 6)
-    bytsUTF8(0) = (i And 31) Or 192 ' 31 = 00011111, 192 = 11000000
+    bytsUTF8(1) = (lngCodePoint And 63) Or 128 ' 63 = 00111111, 128 = 10000000
+    lngCodePoint = bit16ShiftR(lngCodePoint, 6)
+    bytsUTF8(0) = (lngCodePoint And 31) Or 192 ' 31 = 00011111, 192 = 11000000
     UCS2CP_to_UTF8CP = True
   Else
     ' encoded in 3 bytes in UTF8
     ReDim bytsUTF8(2)
-    bytsUTF8(2) = (i And 63) Or 128 ' 63 = 0011 1111, 128 = 1000 0000
-    i = bit16ShiftR(i, 6)
-    bytsUTF8(1) = (i And 63) Or 128 ' 63 = 0011 1111, 128 = 1000 0000
-    i = bit16ShiftR(i, 6)
-    bytsUTF8(0) = (i And 15) Or 224 ' 15 = 00001111, 224 = 11100000
+    bytsUTF8(2) = (lngCodePoint And 63) Or 128 ' 63 = 0011 1111, 128 = 1000 0000
+    lngCodePoint = bit16ShiftR(lngCodePoint, 6)
+    bytsUTF8(1) = (lngCodePoint And 63) Or 128 ' 63 = 0011 1111, 128 = 1000 0000
+    lngCodePoint = bit16ShiftR(lngCodePoint, 6)
+    bytsUTF8(0) = (lngCodePoint And 15) Or 224 ' 15 = 00001111, 224 = 11100000
     UCS2CP_to_UTF8CP = True
   End If
+End Function
+Private Function bit16ShiftL(i As Long, s As Integer) As Long
+  ' takes a 16 bit numeric (passed in as Long) and bit shifts it left by the specified number of bits
+  bit16ShiftL = bit16ShiftR(i, -s)
 End Function
 
 Private Function bit16ShiftR(i As Long, s As Integer) As Long
@@ -253,5 +299,5 @@ Private Function bit16ShiftR(i As Long, s As Integer) As Long
   
   bit16ShiftR = Fix(bit16ShiftR / (2 ^ s))
   
-  bit16ShiftR = bit16ShiftR And 65535 '&HFFFF
+  bit16ShiftR = bit16ShiftR And 65535 '&HFFFF ' ensure we only have least significant 16 bits
 End Function

--- a/Modules/modFileEncoding.ACM
+++ b/Modules/modFileEncoding.ACM
@@ -1,0 +1,257 @@
+Option Compare Database
+Option Explicit
+
+Private Declare Sub CopyMemory Lib "kernel32" Alias "RtlMoveMemory" (ByVal Destination As Any, ByVal Source As Any, ByVal Length As Long)
+
+Function IsUCS2(strFilename As String) As Boolean
+  ' Returns true if the file specified is in UCS2 little endian format
+  Dim f As Long
+  Dim byts() As Byte
+  
+  If FileExists(strFilename) Then
+    ' load the file into the bytsFile array
+    f = FreeFile()
+    Open strFilename For Binary Access Read As #f
+    ReDim byts(2)
+    Get #f, 1, byts()
+    Close #f
+    IsUCS2 = ((byts(0) = 255) And (byts(1) = 254))
+  End If
+End Function
+
+Function ConvFileUTF8_to_UCS2(strFilename As String, Optional strNewFilename As String) As Boolean
+  ' Converts the supplied file from UTF8 to UCS2 format
+  Dim byts() As Byte
+  Dim bytsOut() As Byte
+  
+  If LenB(strNewFilename) = 0 Then strNewFilename = strFilename
+  If ReadFromFile(strFilename, byts) Then
+    If UTF8_to_UCS2(byts, bytsOut) Then
+      ConvFileUTF8_to_UCS2 = WriteToFile(bytsOut, strNewFilename)
+    End If
+  End If
+    
+End Function
+
+Function ConvFileUCS2_to_UTF8(strFilename As String, Optional strNewFilename As String) As Boolean
+  ' Converts the supplied file from UCS2 to UTF8 format
+  Dim byts() As Byte
+  Dim bytsOut() As Byte
+  
+  If LenB(strNewFilename) = 0 Then strNewFilename = strFilename
+  If ReadFromFile(strFilename, byts) Then
+    If UCS2_to_UTF8(byts, bytsOut) Then
+      ConvFileUCS2_to_UTF8 = WriteToFile(bytsOut, strNewFilename)
+    End If
+  End If
+    
+End Function
+
+Function ReadFromFile(strFilename As String, byts() As Byte) As Boolean
+  ' Reads data from the supplied file into the supplied byte array
+  
+  Dim f As Long
+  
+  If FileExists(strFilename) Then
+    ' load the file into the bytsFile array
+    f = FreeFile()
+    Open strFilename For Binary Access Read As #f
+    ReDim byts(LOF(f) - 1)
+    Get #f, , byts()
+    Close #f
+    ReadFromFile = True
+  End If
+End Function
+
+Function WriteToFile(byts() As Byte, strFilename As String) As Boolean
+  ' Writes data from the supplied byte array into the file specified
+  Dim f As Long
+  
+  If FileExists(strFilename) Then Kill strFilename
+  
+  ' Open file ready for output
+  f = FreeFile()
+  Open strFilename For Binary Access Write As #f
+  Put #f, 1, byts
+  Close #f
+  
+  WriteToFile = True
+  
+End Function
+
+Function UCS2_to_UTF8(bytsUCS2() As Byte, ByRef bytsUTF8() As Byte) As Boolean
+  ' This converts a UCS2 Little Endian encoded byte array into UTF8
+  ' Returns True if successful, False if it fails for any reason
+  
+  Dim lenUCS2 As Long
+  Dim b As Long ' The next write position in the UTF8 byte array
+  Dim i As Long ' The current byte position in UCS2 byte array
+  Dim CP_UCS2(1) As Byte
+  Dim CP_UTF8() As Byte
+  
+  UCS2_to_UTF8 = False ' intially set return value to be false
+  
+  lenUCS2 = UBound(bytsUCS2) - LBound(bytsUCS2) + 1
+  
+  ' Check that the length of the UCS2 array is at least 2 bytes
+  If lenUCS2 < 2 Then Exit Function
+  
+  ' Check that the length of the UCS2 array is an even number of bytes
+  If lenUCS2 Mod 2 <> 0 Then Exit Function
+  
+  ' Check that the supplied array has the correct Byte Order Mark (BOM)
+  If bytsUCS2(LBound(bytsUCS2)) <> 255 Or bytsUCS2(LBound(bytsUCS2) + 1) <> 254 Then Exit Function '255 = &HFF, 254 = &HFE
+  
+  ' Redim bytsUTF8 to the maximum it can be ( max 3 bytes per character )
+  ' ignore header of UCS2 (2 bytes) then for each 2 bytes in UCS2 need potentially 3 bytes in UTF8
+  If lenUCS2 = 2 Then
+    ' we need to return an empty array
+    Erase bytsUTF8
+    UCS2_to_UTF8 = True
+    Exit Function
+  End If
+  
+  ReDim bytsUTF8((lenUCS2 - 2) * 3 / 2 - 1)
+  
+  For i = LBound(bytsUCS2) + 2 To UBound(bytsUCS2) Step 2
+    CopyMemory VarPtr(CP_UCS2(0)), VarPtr(bytsUCS2(i)), 2 ' Copy CodePoint into CP array
+    If Not UCS2CP_to_UTF8CP(CP_UCS2, CP_UTF8) Then Exit Function
+    CopyMemory VarPtr(bytsUTF8(b)), VarPtr(CP_UTF8(0)), UBound(CP_UTF8) + 1
+    b = b + UBound(CP_UTF8) + 1
+  Next
+  
+  ReDim Preserve bytsUTF8(b - 1)
+  UCS2_to_UTF8 = True
+  
+End Function
+
+Function UTF8_to_UCS2(bytsUTF8() As Byte, ByRef bytsUCS2() As Byte) As Boolean
+  ' This converts a UTF8 encoded byte array into ucs2 Little Endian
+  ' Returns True if successful, False if it fails for any reason
+  
+  Dim b As Long ' The next write position in the UCS2 array
+  Dim CP_UCS2() As Byte
+  Dim lenUTF8 As Long
+  Dim i As Long
+  Dim j As Long
+  
+  UTF8_to_UCS2 = False ' intially set return value to be false
+  
+  lenUTF8 = UBound(bytsUTF8) - LBound(bytsUTF8) + 1
+  
+  ' Redim bytsUCS2 to the maximum it can be (header plus 2 bytes for each byte in UTF8
+  ReDim bytsUCS2(2 + lenUTF8 * 2)
+  
+  ' Write the BOM
+  bytsUCS2(0) = 255
+  bytsUCS2(1) = 254
+  b = 2
+  
+  For i = LBound(bytsUTF8) To UBound(bytsUTF8)
+    j = UTF8CP_to_UCS2CP(bytsUTF8, i, CP_UCS2)
+    If j = 0 Then Exit Function
+    CopyMemory VarPtr(bytsUCS2(b)), VarPtr(CP_UCS2(0)), 2
+    b = b + 2
+    i = i + j - 1
+  Next
+  
+  ReDim Preserve bytsUCS2(b - 1)
+  UTF8_to_UCS2 = True
+  
+End Function
+
+Private Function UTF8CP_to_UCS2CP(bytsUTF8() As Byte, P As Long, bytsUCS2() As Byte) As Long
+  ' This function takes a UTF8 byte array and converts the codepoint at location p into a UCS2 byte array (length 2)
+  ' In the event of an error this function returns zero, otherwise it returns the number
+  ' of bytes which were used to encode the UTF8 character
+  
+  Dim c As Long
+  
+  UTF8CP_to_UCS2CP = 0 ' intitally set to zero (fail)
+  
+  If P > UBound(bytsUTF8) Then Exit Function
+  If P < LBound(bytsUTF8) Then Exit Function
+  
+  ReDim bytsUCS2(1) ' always 2 bytes
+  
+  If (bytsUTF8(P) And 128) = 0 Then '128 = 1000 0000 'this byte is 0xxx xxxx
+    ' We have a single byte UTF8
+    bytsUCS2(0) = bytsUTF8(P)
+    bytsUCS2(1) = 0
+    UTF8CP_to_UCS2CP = 1
+  ElseIf (bytsUTF8(P) And 224) = 192 Then  '224 = 1110 0000, 192 = 1100 0000 'this byte is 110x xxxx
+    If UBound(bytsUTF8) < P + 1 Then Exit Function 'check we have enough bytes left
+    If (bytsUTF8(P + 1) And 192) <> 128 Then Exit Function '192 = 1100 0000, 128 = 1000 0000 2nd byte must be 10xx xxxx
+    ' We have a valid 2 byte UTF8
+    c = bit16ShiftR((bytsUTF8(P) And 31), -6) '31 = 0001 1111
+    c = c Or (bytsUTF8(P + 1) And 63) '63 = 0011 1111
+    bytsUCS2(0) = c And 255 '255 = 1111 1111  least significant byte
+    bytsUCS2(1) = bit16ShiftR(c, 8) ' most significant Byte
+    UTF8CP_to_UCS2CP = 2
+  ElseIf (bytsUTF8(P) And 240) = 224 Then '240 = 1111 0000, 224 = 1110 0000 'this byte is 1110 xxxx
+    If UBound(bytsUTF8) < P + 2 Then Exit Function 'check we have enough bytes left
+    If (bytsUTF8(P + 1) And 192) <> 128 Then Exit Function '2nd byte must be 10xx xxxx
+    If (bytsUTF8(P + 2) And 192) <> 128 Then Exit Function '3rd byte must be 10xx xxxx
+    ' We have a valid 3 byte UTF8
+    c = bit16ShiftR((bytsUTF8(P) And 15), -12) '15 = 0000 1111
+    c = c Or bit16ShiftR((bytsUTF8(P + 1) And 63), -6) '63 = 0011 1111
+    c = c Or (bytsUTF8(P + 2) And 63) '63 = 0011 1111
+    bytsUCS2(0) = c And 255 '255 = 1111 1111  least significant byte
+    bytsUCS2(1) = bit16ShiftR(c, 8) ' most significant Byte
+    UTF8CP_to_UCS2CP = 3
+  Else
+    ' we cannot deal with 4 byte UTF8 so we get an error
+    Exit Function
+  End If
+    
+End Function
+
+Private Function UCS2CP_to_UTF8CP(bytsUCS2() As Byte, bytsUTF8() As Byte) As Boolean
+  ' This function takes a 2 byte zero based array encoded in UCS2 and returns a 1 to 3 byte array encoded in UTF8
+  
+  Dim i As Long ' this is used to represent the character we have
+  Dim j As Long
+  
+  UCS2CP_to_UTF8CP = False ' intially set return value to be false
+  
+  If LBound(bytsUCS2) <> 0 Then Exit Function
+  If UBound(bytsUCS2) <> 1 Then Exit Function
+  
+  i = bytsUCS2(1) * 256 + bytsUCS2(0) ' Little Endian
+  
+  If i < 128 Then '128 = &H80
+    ' encoded in 1 byte in UTF8
+    ReDim bytsUTF8(0)
+    bytsUTF8(0) = i
+    UCS2CP_to_UTF8CP = True
+  ElseIf i < 2048 Then '2048 = &H0800
+    ' encoded in 2 bytes in UTF8
+    ReDim bytsUTF8(1)
+    bytsUTF8(1) = (i And 63) Or 128 ' 63 = 00111111, 128 = 10000000
+    i = bit16ShiftR(i, 6)
+    bytsUTF8(0) = (i And 31) Or 192 ' 31 = 00011111, 192 = 11000000
+    UCS2CP_to_UTF8CP = True
+  Else
+    ' encoded in 3 bytes in UTF8
+    ReDim bytsUTF8(2)
+    bytsUTF8(2) = (i And 63) Or 128 ' 63 = 0011 1111, 128 = 1000 0000
+    i = bit16ShiftR(i, 6)
+    bytsUTF8(1) = (i And 63) Or 128 ' 63 = 0011 1111, 128 = 1000 0000
+    i = bit16ShiftR(i, 6)
+    bytsUTF8(0) = (i And 15) Or 224 ' 15 = 00001111, 224 = 11100000
+    UCS2CP_to_UTF8CP = True
+  End If
+End Function
+
+Private Function bit16ShiftR(i As Long, s As Integer) As Long
+  ' takes 16 bit numeric (passed in as long) and bit shifts it right by the specified number of bits
+  ' if we are shifting left (-ve s) then we will loose the left most s bits
+  
+  If s > 15 Then bit16ShiftR = 0: Exit Function
+  If s < -15 Then bit16ShiftR = 0: Exit Function
+  bit16ShiftR = i And 65535 '&HFFFF
+  
+  bit16ShiftR = Fix(bit16ShiftR / (2 ^ s))
+  
+  bit16ShiftR = bit16ShiftR And 65535 '&HFFFF
+End Function


### PR DESCRIPTION
Implements Issue #30 as an option in the Export section.

For a new repository the default is to us UTF-8.

Closes #30 
