### PR TITLE
Fixed Issue #43

### DIFF
--- a/Forms/Access SVN - Options.ACF
+++ b/Forms/Access SVN - Options.ACF
@@ -2539,9 +2539,9 @@ Private Sub Form_Load()
 
   Call SCC_IsSupportedClient  ' Throw any warnings before doing anything
 
+  UpdateVersionDetails
   If Me.chkRepository = True And Me.txtLastVersion.Value <> "" And Me.txtLastVersion.Value <> -1 Then
     ' This is not first use of this DB, and startup check is enabled
-    UpdateVersionDetails
     pvt_CheckVersionWarnings
   Else
     Me.txtLatestVersion.Value = ""

--- a/Modules/asMain.ACM
+++ b/Modules/asMain.ACM
@@ -1410,20 +1410,31 @@ Private Sub asPopulateTmpObjectsImport(objType As asObjectDBType, strImportPath 
   Set rst1 = db.OpenRecordset("SELECT * FROM MSysSCCTmpObjects", dbOpenDynaset)
   
   SCC_GetAllVersionsSubFolder strImportPath, arrSVNItems
-  For j = LBound(arrSVNItems) To UBound(arrSVNItems)
-    If arrSVNItems(j).svName <> "" Then
-      strObjName = winPathSpecialCharsDecode(Left$(arrSVNItems(j).svName, Len(arrSVNItems(j).svName) - 4))
-      rst1.AddNew
-      rst1!objName = strObjName
-      rst1!objType = objType
-      strStatus = getObjectSVNStatus(objType, strObjName, arrSVNItems(j))
-      rst1!objStatus = strStatus
-      If strStatus = "Unchanged" Then
-        rst1!selected = False
+  If (Not arrSVNItems) <> -1 Then ' check that the arr is not nothing before looping through it
+    For j = LBound(arrSVNItems) To UBound(arrSVNItems)
+      If arrSVNItems(j).svName <> "" Then
+        strObjName = winPathSpecialCharsDecode(Left$(arrSVNItems(j).svName, Len(arrSVNItems(j).svName) - 4))
+        rst1.AddNew
+        rst1!objName = strObjName
+        rst1!objType = objType
+        strStatus = getObjectSVNStatus(objType, strObjName, arrSVNItems(j))
+        rst1!objStatus = strStatus
+        If strStatus = "Unchanged" Then
+          rst1!selected = False
+        End If
+        On Error Resume Next
+        rst1.Update
+        If Err = 3022 Then 'duplicate record
+          ' This is most likely caused by the directory selected containing more than one version/branch of the repository
+          rst1.CancelUpdate
+          asPurgeTmpObjectsTables
+          Erase arrSVNItems()
+          Exit For
+        End If
+        On Error GoTo 0
       End If
-      rst1.Update
-    End If
-  Next j
+    Next j
+  End If
   
   ' Get a list of all objects that are in the status table (found in SVN repo) but are not in the list from Access
   ' which means they have been deleted from the latest repository.

--- a/Modules/modSVN.ACM
+++ b/Modules/modSVN.ACM
@@ -321,13 +321,16 @@ Public Function SVN_GetAllVersionsSubFolder(strPath As String, ByRef arrFill() A
   Dim i As Long, j As Long
   Dim mySvnItem As SVNITEM
   Dim intArrSize As Integer
+  Dim strFolder As String
   
   i = 0: j = 0
   intArrSize = 100
   
   On Error GoTo SVN_GetAllVersionsSubFolder_Err
   
-  strCmd = GetSVNPath() & " info -R """ & stripSlash(strPath) & """"
+  strFolder = stripSlash(strPath)
+  If Not FileExists(strFolder) Then Exit Function
+  strCmd = GetSVNPath() & " info -R """ & strFolder & """"
   strRet = ExecAndCapture(strCmd, TempDir()) ' run in a temp folder, to ensure the path output is absolute, not relative
   If LenB(strRet) = 0 Then Exit Function
     


### PR DESCRIPTION
Test 1: Run asPopulateTmpObjects with non existing folder, SVN folder which is not an MS Access SVN repository, and valid repository
```
Public Function Test()
  Dim a() As SVNITEM
  asPurgeTmpObjectsTables
  'Call asPopulateTmpObjectsImport(objForm, "", a)
  'Call asPopulateTmpObjectsImport(objForm, "C:\SVN\access-scc-addin.git", a)
  Call asPopulateTmpObjectsImport(objForm, "C:\SVN\access-scc-addin.git\branches\Fix-Issue-43-Disable-Import-Button", a)
End Function
```
  
Also tested add in shows Import Button disabled on start up when export folder is not an MS Access SVN repository