### PR TITLE
Fallback to finding references in Distributables

### DIFF
--- a/Modules/asMain.ACM
+++ b/Modules/asMain.ACM
@@ -131,7 +131,7 @@ Public Function ImportSilent(strSccSystem As String, strImportPath As String, Op
   asImportObjects objReport, strImportPath & "Reports\", strError       ' Reports
   asImportObjects objModule, strImportPath & "Modules\", strError       ' Modules
   asImportObjects objToolbar, strImportPath & "Toolbars\", strError     ' Toolbars
-  asImportObjects objReference, strImportPath & "References\", strError ' References
+  asImportObjects objReference, strImportPath & "References\", strError, strImportRootPath:=strImportPath   ' References
   asImportObjects objIMEXSpecs, strImportPath & "IMEXSpecs\", strError  ' Import Export Specs
   If Not blnSkipMacrosAndExtras Then
     asImportObjects objMacro, strImportPath & "Macros\", strError         ' Macros
@@ -762,7 +762,7 @@ Public Sub asUpdateVersionsFromExport(strExportPath As String)
          
 End Sub
 
-Private Sub asImportObject(objType As asObjectDBType, objName As String, objStatus As String, strImportPath As String, Optional ByRef strError As String)
+Private Sub asImportObject(objType As asObjectDBType, objName As String, objStatus As String, strImportPath As String, Optional strImportRootPath As String, Optional ByRef strError As String)
   Dim strImportFileName As String, strObjectType As String
   Dim strLoadError As String
 
@@ -783,7 +783,7 @@ Private Sub asImportObject(objType As asObjectDBType, objName As String, objStat
       
     Case "New"
       SetStatus "Importing " & strObjectType & " '" & objName & "' from " & appendSlash(strImportPath) & strImportFileName
-      LoadFromText asGetAccessType(objType), objName, appendSlash(strImportPath) & strImportFileName, strLoadError
+      LoadFromText asGetAccessType(objType), objName, appendSlash(strImportPath) & strImportFileName, strImportRootPath, strLoadError
       If strLoadError <> "" Then
         AddResult "Error importing " & objName & ": " & strLoadError & vbCrLf, strError
         strLoadError = ""
@@ -792,7 +792,7 @@ Private Sub asImportObject(objType As asObjectDBType, objName As String, objStat
       
     Case Else
       SetStatus "Importing " & strObjectType & " '" & objName & "' from " & appendSlash(strImportPath) & strImportFileName
-      LoadFromText asGetAccessType(objType), objName, appendSlash(strImportPath) & strImportFileName, strLoadError
+      LoadFromText asGetAccessType(objType), objName, appendSlash(strImportPath) & strImportFileName, strImportRootPath, strLoadError
       If strLoadError <> "" Then
         AddResult "Error importing " & objName & ": " & strLoadError & vbCrLf
         strLoadError = ""
@@ -874,7 +874,7 @@ Private Sub asDeleteObject(objType As asObjectDBType, objName As String)
 
 End Sub
 
-Private Sub asImportObjects(objImportType As asObjectDBType, strImportPath As String, Optional ByRef strError As String)
+Private Sub asImportObjects(objImportType As asObjectDBType, strImportPath As String, Optional ByRef strError As String, Optional strImportRootPath As String)
   On Error GoTo Err_asImportObjects
   
   Dim db As DAO.Database
@@ -891,7 +891,7 @@ Private Sub asImportObjects(objImportType As asObjectDBType, strImportPath As St
   
   ' Import all the objects
   Do Until rst.EOF
-    asImportObject rst!objType, rst!objName, rst!objStatus, strImportPath, strError
+    asImportObject rst!objType, rst!objName, rst!objStatus, strImportPath, strImportRootPath, strError
     rst.MoveNext
   Loop
 
@@ -935,7 +935,7 @@ Private Sub asImportAllFromText(strExportPath As String)
     If Application.Forms![Access SVN - Options].chkModules.Value = True Then asImportObjects objModule, strExportPath & "Modules\"          ' Modules
     If Application.Forms![Access SVN - Options].chkCmdBars.Value = True Then asImportObjects objToolbar, strExportPath & "Toolbars\"        ' Toolbars
     If Application.Forms![Access SVN - Options].chkExtras.Value = True Then asImportObjects objExtra, strExportPath & "Extras\"             ' Extras
-    If Application.Forms![Access SVN - Options].chkReferences.Value = True Then asImportObjects objReference, strExportPath & "References\" ' References
+    If Application.Forms![Access SVN - Options].chkReferences.Value = True Then asImportObjects objReference, strExportPath & "References\", strImportRootPath:=strExportPath ' References
     If Application.Forms![Access SVN - Options].chkImportExport.Value = True Then asImportObjects objIMEXSpecs, strExportPath & "IMEXSpecs\"   ' Import Export Specs
     
     Echo True

--- a/Modules/modExtendSaveAsText.ACM
+++ b/Modules/modExtendSaveAsText.ACM
@@ -380,6 +380,8 @@ End Sub
 '
 ' @version 1.01
 ' @param    String the filename to import references from
+' @param    String the import root path, under which we will look for
+'           the Distributables folder.
 '************************************************
 Public Sub LoadReferencesFromText(FileName As String, strImportRootPath As String)
   Dim f As Integer, i As Integer

--- a/Modules/modExtendSaveAsText.ACM
+++ b/Modules/modExtendSaveAsText.ACM
@@ -172,7 +172,7 @@ End_Processing:
 End Sub
 
 
-Public Sub LoadFromText(objType As asObjectType, ByVal objName As String, strFilename As String, Optional strErr As String)
+Public Sub LoadFromText(objType As asObjectType, ByVal objName As String, strFilename As String, strImportRootPath As String, Optional strErr As String)
   Dim strCatchErr As String
   Dim blnUTF8 As Boolean
   Dim strTempFilename As String
@@ -236,7 +236,7 @@ Public Sub LoadFromText(objType As asObjectType, ByVal objName As String, strFil
       LoadExtraFromText strTempFilename
       
     Case asObjectType.acReference
-      LoadReferencesFromText strTempFilename
+      LoadReferencesFromText strTempFilename, strImportRootPath
       
   End Select
   
@@ -357,10 +357,15 @@ End Sub
 '
 ' @param    String the filename to import references from
 '************************************************
-Public Sub LoadReferencesFromText(FileName As String)
-
+Public Sub LoadReferencesFromText(FileName As String, strImportRootPath As String)
   Dim f As Integer, i As Integer
-  Dim strLine As String, strGUID As String, strMajor As String, strMinor As String, strName As String, strFullPath As String
+  Dim strLine As String
+  Dim strGUID As String
+  Dim strMajor As String
+  Dim strMinor As String
+  Dim strName As String
+  Dim strFullPath As String
+  Dim str As String
   Dim lngError As Long
   Dim ref As Access.Reference
   
@@ -418,23 +423,42 @@ Public Sub LoadReferencesFromText(FileName As String)
         
         On Error Resume Next
         Application.References.AddFromGuid strGUID, strMajor, strMinor
-        lngError = Err
+        lngError = Err.Number
         On Error GoTo 0
-        If lngError <> 0 Then
-          'Couldn't register the library
-          lngError = 0
-          On Error Resume Next
-          Application.References.AddFromFile strFullPath
-          lngError = Err
-          On Error GoTo 0
-          If lngError <> 0 Then
-            MsgBox "Unable to create reference to the " & strName & " " & strMajor & "." & strMinor & " (" & strFullPath & ") Library."
+        If lngError = 0 Then
+          GoTo Proc_Next
+        End If
+        
+        'Couldn't register the library, try adding from file
+        On Error Resume Next
+        Application.References.AddFromFile strFullPath
+        lngError = Err.Number
+        On Error GoTo 0
+        If lngError = 0 Then
+          GoTo Proc_Next
+        End If
+        
+        'Couldn't register the library, try adding from distributables
+        If LenB(strImportRootPath) <> 0 Then
+          str = appendSlash(strImportRootPath) & "Distributables\" & ShortName(strFullPath)
+          If FileExists(str) Then
+            On Error Resume Next
+            Application.References.AddFromFile str
+            lngError = Err.Number
+            On Error GoTo 0
+            If lngError = 0 Then
+              GoTo Proc_Next
+            End If
           End If
         End If
+        
+        
+        MsgBox "Unable to create reference to the " & strName & " " & strMajor & "." & strMinor & " (" & strFullPath & ") Library."
         
       Case Else
         Stop 'Shouldn't have anything else!
     End Select
+Proc_Next:
   Loop
 End Sub
 

--- a/Modules/modExtendSaveAsText.ACM
+++ b/Modules/modExtendSaveAsText.ACM
@@ -351,10 +351,34 @@ Public Sub SaveReferencesAsText(FileName As String)
 End Sub
 
 '************************************************
-' Imports references info about the DB file from a Text file
+' Import references from a text file
 '
-' Used with SVN to store table definitions
+' The order a reference is loaded is:
+' - GUID
+'     This will pick up registered DLLs.
+' - By FullPath
+'     This will pick up DLLs that are not registered, but are in a standard
+'     location.
+' - Under Distributables
+'     This resolves two problems with running Access build machines that need
+'     to build (but not run) ad-hoc databases.
 '
+'     Firstly there is a version handling issue with some libraries
+'     (e.g. Chilkat) where many versions of the library have the same GUID
+'     and version numbers. In this case you can not install both versions of
+'     the library on your build machine. Note that this results in building
+'     databases that can not actually be run on the build machine.
+'
+'     A second benefit is that new libraries can be added by including them in
+'     the Distributables folder, you do not need to register the library on
+'     the build machine.
+'
+'
+' Version history:
+' - 1.00 initial version ??/??/????
+' - 1.01 Add a fallback to find references in Distributables
+'
+' @version 1.01
 ' @param    String the filename to import references from
 '************************************************
 Public Sub LoadReferencesFromText(FileName As String, strImportRootPath As String)

--- a/Modules/xwFileFunctions - Partial.ACM
+++ b/Modules/xwFileFunctions - Partial.ACM
@@ -1,0 +1,25 @@
+Option Compare Database
+Option Explicit
+
+
+'************************************************
+' Short Name
+'
+' This function returns the filename when a full path is supplied
+'
+' @author
+' @version      1.00
+' @suggestions  Could just use findlast function to locate the last "\" character
+' @param        Variant the full pathname to examine
+' @return       Variant the filename part of the path
+'************************************************
+Function ShortName(ByVal Full As Variant) As Variant
+  Dim x As Variant
+  
+  x = 1
+  Do
+    x = InStr(x + 1, Full, "\")
+  Loop Until InStr(x + 1, Full, "\") = 0
+  ' x is position of last \
+  ShortName = Right$(Full, Len(Full) - x)
+End Function


### PR DESCRIPTION
If ref cannon be found by GUID or FullPath, try looking in
<Import Path>\Distributables\<Ref File Name>

The project that is built won't actually be able to run, as the ref will not
be able to resolve at runtime if it hasn't been registered with RegSvr32.

This allows you to have a generic Access build computer, that doesn't need any
particular prerequisite libraries installed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x-ware-ltd/access-scc-addin/64)
<!-- Reviewable:end -->
