### PR TITLE
Automatically re-import references if any are broken

### DIFF
--- a/Modules/asMain.ACM
+++ b/Modules/asMain.ACM
@@ -125,6 +125,11 @@ Public Function ImportSilent(strSccSystem As String, strImportPath As String, Op
     asPopulateTmpObjectsImport objExtra, strImportPath & "Extras", modSCC.arrExtras             ' Extras
   End If
   
+  ' If there are broken references, reimport the references even if they are unchanged
+  If ReferencesBroken() Then
+    CodeDb.Execute "UPDATE MSysSCCTmpObjects IN '" & CurrentDb.Name & "' SET selected = TRUE WHERE objType = " & CInt(objReference)
+  End If
+  
   asImportObjects objTable, strImportPath & "Tables\", strError         ' Tables
   asImportObjects objQuery, strImportPath & "Queries\", strError        ' Queries
   asImportObjects objForm, strImportPath & "Forms\", strError           ' Forms
@@ -140,6 +145,20 @@ Public Function ImportSilent(strSccSystem As String, strImportPath As String, Op
   
   ImportSilent = strError
   asPurgeTmpObjectsTables
+End Function
+
+Public Function ReferencesBroken() As Boolean
+  Dim ref As Reference
+  
+  For Each ref In Application.References
+    If Not ref.IsBroken Then
+      ReferencesBroken = True
+      Exit Function
+    End If
+  Next
+  
+  ' If we get here no references are broken
+  ReferencesBroken = False
 End Function
     
 Public Function asRunExport()

--- a/Modules/modExtendSaveAsText.ACM
+++ b/Modules/modExtendSaveAsText.ACM
@@ -344,7 +344,12 @@ Public Sub SaveReferencesAsText(FileName As String)
       Print #f, "        GUID = " & ref.Guid
       Print #f, "        Major = " & ref.Major
       Print #f, "        Minor = " & ref.Minor
+      On Error Resume Next
+      ' If a dll is not registered getting the FullPath will fail
+      ' in this case, When this is being called from UpdateObjectProperties the
+      ' references will show as changed
       Print #f, "        FullPath = " & ref.FullPath
+      On Error GoTo 0
       Print #f, "    End"
     End If
   Next


### PR DESCRIPTION
This fixes an issue we had where the build made by the add-in failed to compile, when libraries are installed in `<import path>/Distributables`. This is a fix/completion of the work done in #64.

## Proposed Commit message:
```
Fix references on import. This allows compiling the database on a machine that
does not have References installed/registered ( when libraries are installed in
`<import path>/Distributables`). This is a fix/completion of the work done in
#64.

Also protect against the FullPath of a Reference not being available. This
happens if a Reference is not registered.
```


I have tested this change locally, and will load it onto the build server to confirm it works there as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x-ware-ltd/access-scc-addin/68)
<!-- Reviewable:end -->
