### PR TITLE
Add support for library imports

### DIFF
--- a/Forms/Access SVN - Options.ACF
+++ b/Forms/Access SVN - Options.ACF
@@ -2797,7 +2797,7 @@ Private Sub Form_Load()
   Me.txtOutputLocation.SetFocus
 
   DoCmd.Hourglass True
-  strRecordSource = "SELECT ExportPath, CommitAfterExport, UpdateBeforeImport, QueriesFlag, FormsFlag, ReportsFlag, MacrosFlag, ModulesFlag, TablesFlag, ToolbarsFlag, ExtrasFlag, ReferencesFlag, ImExSpecsFlag, RelationshipsFlag, LastImportDate, LastCheckoutVersion, CheckRepoOnSartup, ShowCommitWindow, ShowUpdateWindow, SccSystem FROM MSysSCCPrefs IN '" & CurrentDb().Name & "'"
+  strRecordSource = "SELECT ExportPath, CommitAfterExport, UpdateBeforeImport, QueriesFlag, FormsFlag, ReportsFlag, MacrosFlag, ModulesFlag, TablesFlag, ToolbarsFlag, ExtrasFlag, ReferencesFlag, ImExSpecsFlag, RelationshipsFlag, LastImportDate, LastCheckoutVersion, CheckRepoOnSartup, ShowCommitWindow, ShowUpdateWindow, SccSystem FROM MSysSCCPrefs IN '" & CurrentDb().Name & "' WHERE Library IS NULL"
 
   Me.RecordSource = strRecordSource
   

--- a/Modules/asCreateTables.ACM
+++ b/Modules/asCreateTables.ACM
@@ -45,6 +45,14 @@ Public Sub CreateLocalSCCTables()
     Set fd = AddField(db.TableDefs("MSysSCCPrefs"), "SccSystem", dbLong, 0, "The SCC system in use. From the SccSystem enum", , , , , , , , True)
   End If
   
+  If InFields(db.TableDefs("MSysSCCPrefs").Fields, "Library") = False Then
+    Set fd = AddField(db.TableDefs("MSysSCCPrefs"), "Library", dbText, 100, "The library these preferences apply to", bRequired:=True, bAllowZeroLength:=True, vDefaultValue:=vbNullString)
+  End If
+  
+  If InFields(db.TableDefs("MSysSCCStatus").Fields, "objSourceLibrary") = False Then
+    Set fd = AddField(db.TableDefs("MSysSCCStatus"), "objSourceLibrary", dbText, 100, "The library these this object comes from", bRequired:=True, bAllowZeroLength:=True, vDefaultValue:=vbNullString)
+  End If
+  
   db.Close: Set db = Nothing
 End Sub
 

--- a/Modules/asCreateTables.ACM
+++ b/Modules/asCreateTables.ACM
@@ -20,7 +20,6 @@ Option Explicit
 '************************************************
 Public Sub CreateLocalSCCTables()
   Dim db As DAO.Database
-  Dim fd As DAO.Field
   
   Set db = CurrentDb()
   
@@ -36,42 +35,32 @@ Public Sub CreateLocalSCCTables()
   If Not TableExists(db, "MSysSCCStatus") Then CreateSCCStatusTable db
   If Not TableExists(db, "MSysSCCPrefs") Then CreateSCCPrefsTable db
   
-  If InFields(db.TableDefs("MSysSCCPrefs").Fields, "ShowCommitWindow") = False Then
-    Set fd = AddField(db.TableDefs("MSysSCCPrefs"), "ShowCommitWindow", dbBoolean, 0, "Whether to show the commit window, or auto close it", , , , , , , , True)
-    Set fd = AddField(db.TableDefs("MSysSCCPrefs"), "ShowUpdateWindow", dbBoolean, 0, "Whether to show the update window, or auto close it", , , , , , , , True)
-  End If
   
-  If InFields(db.TableDefs("MSysSCCPrefs").Fields, "SccSystem") = False Then
-    Set fd = AddField(db.TableDefs("MSysSCCPrefs"), "SccSystem", dbLong, 0, "The SCC system in use. From the SccSystem enum", , , , , , , , True)
-  End If
-  
-  If InFields(db.TableDefs("MSysSCCPrefs").Fields, "Library") = False Then
-    Set fd = AddField(db.TableDefs("MSysSCCPrefs"), "Library", dbText, 100, "The library these preferences apply to", bRequired:=True, bAllowZeroLength:=True, vDefaultValue:=vbNullString)
-  End If
-  
-  If InFields(db.TableDefs("MSysSCCStatus").Fields, "objSourceLibrary") = False Then
-    Set fd = AddField(db.TableDefs("MSysSCCStatus"), "objSourceLibrary", dbText, 100, "The library these this object comes from", bRequired:=True, bAllowZeroLength:=True, vDefaultValue:=vbNullString)
-  End If
+  AddField db.TableDefs("MSysSCCPrefs"), "ShowCommitWindow", dbBoolean, 0, "Whether to show the commit window, or auto close it", , , , , , , , True
+  AddField db.TableDefs("MSysSCCPrefs"), "ShowUpdateWindow", dbBoolean, 0, "Whether to show the update window, or auto close it", , , , , , , , True
+  AddField db.TableDefs("MSysSCCPrefs"), "SccSystem", dbLong, 0, "The SCC system in use. From the SccSystem enum", , , , , , , , True
+  AddField db.TableDefs("MSysSCCPrefs"), "Library", dbText, 100, "The library these preferences apply to", bRequired:=True, bAllowZeroLength:=True, vDefaultValue:=vbNullString
+  AddField db.TableDefs("MSysSCCStatus"), "objSourceLibrary", dbText, 100, "The library these this object comes from", bRequired:=True, bAllowZeroLength:=True, vDefaultValue:=vbNullString
+
   
   db.Close: Set db = Nothing
 End Sub
 
 Private Function CreateSCCObjectPropertiesTable(db As DAO.Database)
-  Dim fd As DAO.Field
   Dim td As DAO.TableDef
   Dim Idx As DAO.Index
   
   Set td = db.CreateTableDef("MSysSCCObjectProperties")
   
-  Set fd = AddField(td, "Temp", dbText, 1)
+  AddField td, "Temp", dbText, 1
   db.TableDefs.Append td
-  Set fd = AddField(td, "objType", dbLong, 0, "Object Type identifier", , , , 1)
-  Set fd = AddField(td, "objName", dbText, 255, "The name of the access object", , , , 0, , True)
-  Set fd = AddField(td, "objID", dbText, 50, "The internal ID of the access object", , , , 1, , False, True)
-  Set fd = AddField(td, "ParentID", dbLong, 0, "The object parent ID", , , , 1, , False)
-  Set fd = AddField(td, "objCreateDate", dbDouble, 0, "The object creation date")
-  Set fd = AddField(td, "objUpdateDate", dbDouble, 0, "The object update date")
-  Set fd = AddField(td, "objUpdateChecksum", dbText, 50, "The current MD5 Checksum of the object, used when date modified is not available", , , , 0, , False, True)
+  AddField td, "objType", dbLong, 0, "Object Type identifier", , , , 1
+  AddField td, "objName", dbText, 255, "The name of the access object", , , , 0, , True
+  AddField td, "objID", dbText, 50, "The internal ID of the access object", , , , 1, , False, True
+  AddField td, "ParentID", dbLong, 0, "The object parent ID", , , , 1, , False
+  AddField td, "objCreateDate", dbDouble, 0, "The object creation date"
+  AddField td, "objUpdateDate", dbDouble, 0, "The object update date"
+  AddField td, "objUpdateChecksum", dbText, 50, "The current MD5 Checksum of the object, used when date modified is not available", , , , 0, , False, True
   td.Fields.Delete "Temp"
   
   Set Idx = td.CreateIndex("PrimaryKey")
@@ -86,19 +75,18 @@ Private Function CreateSCCObjectPropertiesTable(db As DAO.Database)
 End Function
 
 Private Function CreateSCCTmpObjectsTable(db As DAO.Database)
-  Dim fd As DAO.Field
   Dim td As DAO.TableDef
   Dim Idx As DAO.Index
   
   Set td = db.CreateTableDef("MSysSCCTmpObjects")
   
-  Set fd = AddField(td, "Temp", dbText, 1)
+  AddField td, "Temp", dbText, 1
   db.TableDefs.Append td
-  Set fd = AddField(td, "ID", dbLong, 0, "Unique identifier", , , , , True)
-  Set fd = AddField(td, "objName", dbText, 255, "The name of the access object")
-  Set fd = AddField(td, "objType", dbInteger, 0, "The object type")
-  Set fd = AddField(td, "objStatus", dbText, 100, "The object status")
-  Set fd = AddField(td, "selected", dbBoolean, 0, "If object is selected for import export", , , , , , , , True)
+  AddField td, "ID", dbLong, 0, "Unique identifier", , , , , True
+  AddField td, "objName", dbText, 255, "The name of the access object"
+  AddField td, "objType", dbInteger, 0, "The object type"
+  AddField td, "objStatus", dbText, 100, "The object status"
+  AddField td, "selected", dbBoolean, 0, "If object is selected for import export", , , , , , , , True
   td.Fields.Delete "Temp"
   
   Set Idx = td.CreateIndex("primaryIndex")
@@ -123,20 +111,19 @@ Private Function CreateSCCTmpObjectsTable(db As DAO.Database)
 End Function
 
 Public Function CreateSCCStatusTable(db As DAO.Database)
-  Dim fd As DAO.Field
   Dim tdf As DAO.TableDef
   Dim Idx As DAO.Index
   
   Set tdf = db.CreateTableDef("MSysSCCStatus")
-  Set fd = AddField(tdf, "Temp", dbText, 1)
+  AddField tdf, "Temp", dbText, 1
   db.TableDefs.Append tdf
-  Set fd = AddField(tdf, "objType", dbInteger, 0, "The object Type", , , , , True)
-  Set fd = AddField(tdf, "objName", dbText, 255, "The name of the access object")
-  Set fd = AddField(tdf, "objImportVersion", dbText, 100, "The import version")
-  Set fd = AddField(tdf, "objSCCChecksum", dbText, 100, "The current SCC checksum")
-  Set fd = AddField(tdf, "objImportDate", dbDouble, 0, "The import date")
-  Set fd = AddField(tdf, "objImportChecksum", dbText, 50, "The import MD5 Checksum of the object, used when date modified cannot be used for change check", , , , 0, , False, True)
-  Set fd = AddField(tdf, "objStatusUnknown", dbBoolean, 0, "Whether the SCC status is unknown", , , , , , , , False)
+  AddField tdf, "objType", dbInteger, 0, "The object Type", , , , , True
+  AddField tdf, "objName", dbText, 255, "The name of the access object"
+  AddField tdf, "objImportVersion", dbText, 100, "The import version"
+  AddField tdf, "objSCCChecksum", dbText, 100, "The current SCC checksum"
+  AddField tdf, "objImportDate", dbDouble, 0, "The import date"
+  AddField tdf, "objImportChecksum", dbText, 50, "The import MD5 Checksum of the object, used when date modified cannot be used for change check", , , , 0, , False, True
+  AddField tdf, "objStatusUnknown", dbBoolean, 0, "Whether the SCC status is unknown", , , , , , , , False
   tdf.Fields.Delete "Temp"
   
   
@@ -174,34 +161,33 @@ Public Function CreateSCCStatusTable(db As DAO.Database)
 End Function
 
 Private Function CreateSCCPrefsTable(db As DAO.Database)
-  Dim fd As DAO.Field
   Dim td As DAO.TableDef
   Dim strSQL As String
   
   Set td = db.CreateTableDef("MSysSCCPrefs")
   
-  Set fd = AddField(td, "Temp", dbText, 1)
+  AddField td, "Temp", dbText, 1
   db.TableDefs.Append td
-  Set fd = AddField(td, "ExportPath", dbText, 255, "The export path to use in this project", , , , , , , , "C:\SVNRoot\")
-  Set fd = AddField(td, "CommitAfterExport", dbBoolean, 0, "Whether to perform an SVN commit after the export", , , , , , , , True)
-  Set fd = AddField(td, "UpdateBeforeImport", dbBoolean, 0, "Whether to perform an SVN update before an import", , , , , , , , True)
-  Set fd = AddField(td, "QueriesFlag", dbBoolean, 0, "Whether to process queries", , , , , , , , True)
-  Set fd = AddField(td, "FormsFlag", dbBoolean, 0, "Whether to process forms", , , , , , , , True)
-  Set fd = AddField(td, "ReportsFlag", dbBoolean, 0, "Whether to process reports", , , , , , , , True)
-  Set fd = AddField(td, "MacrosFlag", dbBoolean, 0, "Whether to process macros", , , , , , , , True)
-  Set fd = AddField(td, "ModulesFlag", dbBoolean, 0, "Whether to process modules", , , , , , , , True)
-  Set fd = AddField(td, "TablesFlag", dbBoolean, 0, "Whether to process tables", , , , , , , , True)
-  Set fd = AddField(td, "ToolbarsFlag", dbBoolean, 0, "Whether to process toolbars", , , , , , , , True)
-  Set fd = AddField(td, "ExtrasFlag", dbBoolean, 0, "Whether to process extras", , , , , , , , True)
-  Set fd = AddField(td, "ReferencesFlag", dbBoolean, 0, "Whether to process references", , , , , , , , True)
-  Set fd = AddField(td, "ImExSpecsFlag", dbBoolean, 0, "Whether to process import export specs", , , , , , , , True)
-  Set fd = AddField(td, "RelationshipsFlag", dbBoolean, 0, "Whether to process relationships", , , , , , , , True)
-  Set fd = AddField(td, "LastImportDate", dbDate, 0, "The Last Date of an import", , , , , , , , True)
-  Set fd = AddField(td, "LastCheckoutVersion", dbText, 50, "The last version checked out from SVN", , , , , , , , True)
-  Set fd = AddField(td, "CheckRepoOnSartup", dbBoolean, 0, "Whether to check  the repository version on startup", , , , , , , , True)
-  Set fd = AddField(td, "ShowCommitWindow", dbBoolean, 0, "Whether to show the commit window, or auto close it", , , , , , , , True)
-  Set fd = AddField(td, "ShowUpdateWindow", dbBoolean, 0, "Whether to show the update window, or auto close it", , , , , , , , True)
-  Set fd = AddField(td, "SccSystem", dbLong, 0, "The SCC system in use. From the SccSystem enum", , , , , , , , True)
+  AddField td, "ExportPath", dbText, 255, "The export path to use in this project", , , , , , , , "C:\SVNRoot\"
+  AddField td, "CommitAfterExport", dbBoolean, 0, "Whether to perform an SVN commit after the export", , , , , , , , True
+  AddField td, "UpdateBeforeImport", dbBoolean, 0, "Whether to perform an SVN update before an import", , , , , , , , True
+  AddField td, "QueriesFlag", dbBoolean, 0, "Whether to process queries", , , , , , , , True
+  AddField td, "FormsFlag", dbBoolean, 0, "Whether to process forms", , , , , , , , True
+  AddField td, "ReportsFlag", dbBoolean, 0, "Whether to process reports", , , , , , , , True
+  AddField td, "MacrosFlag", dbBoolean, 0, "Whether to process macros", , , , , , , , True
+  AddField td, "ModulesFlag", dbBoolean, 0, "Whether to process modules", , , , , , , , True
+  AddField td, "TablesFlag", dbBoolean, 0, "Whether to process tables", , , , , , , , True
+  AddField td, "ToolbarsFlag", dbBoolean, 0, "Whether to process toolbars", , , , , , , , True
+  AddField td, "ExtrasFlag", dbBoolean, 0, "Whether to process extras", , , , , , , , True
+  AddField td, "ReferencesFlag", dbBoolean, 0, "Whether to process references", , , , , , , , True
+  AddField td, "ImExSpecsFlag", dbBoolean, 0, "Whether to process import export specs", , , , , , , , True
+  AddField td, "RelationshipsFlag", dbBoolean, 0, "Whether to process relationships", , , , , , , , True
+  AddField td, "LastImportDate", dbDate, 0, "The Last Date of an import", , , , , , , , True
+  AddField td, "LastCheckoutVersion", dbText, 50, "The last version checked out from SVN", , , , , , , , True
+  AddField td, "CheckRepoOnSartup", dbBoolean, 0, "Whether to check  the repository version on startup", , , , , , , , True
+  AddField td, "ShowCommitWindow", dbBoolean, 0, "Whether to show the commit window, or auto close it", , , , , , , , True
+  AddField td, "ShowUpdateWindow", dbBoolean, 0, "Whether to show the update window, or auto close it", , , , , , , , True
+  AddField td, "SccSystem", dbLong, 0, "The SCC system in use. From the SccSystem enum", , , , , , , , True
   td.Fields.Delete "Temp"
   
   strSQL = "INSERT INTO [MSysSCCPrefs] (ExportPath) VALUES ('" & CurrentDbDir() & "')"
@@ -256,7 +242,6 @@ End Function
 ' @return Boolean      True if successful, False if not
 '************************************************
 Public Function RenameTable(db As DAO.Database, strOldTableName As String, strNewTableName As String) As Boolean
-  Dim oDB As DAO.Database
   Dim td As DAO.TableDef
 
   On Error GoTo RenameTable_Err

--- a/Modules/asMain.ACM
+++ b/Modules/asMain.ACM
@@ -1457,6 +1457,7 @@ Public Sub asPopulateTmpObjectsExport(objType As asObjectDBType)
 End Sub
 
 Private Function EndsWith(strCheck As String, strMatch As String)
+  ' Returns true if strCheck ends with strMatch
   If Len(strCheck) < Len(strMatch) Then
     Exit Function
   End If
@@ -1465,6 +1466,7 @@ Private Function EndsWith(strCheck As String, strMatch As String)
 End Function
 
 Private Function StartsWith(strCheck As String, strMatch As String)
+  ' Returns true if strCheck starts with strMatch
   If Len(strCheck) < Len(strMatch) Then
     Exit Function
   End If
@@ -1501,7 +1503,6 @@ Private Sub asPopulateTmpObjectsImport(objType As asObjectDBType, strImportPath 
       
       If Not EndsWith(arrSVNItems(j).svName, strFileExtension) Then
         blnSkip = True
-      Else
         AddResult asGetObjectNiceName(objType) & """" & arrSVNItems(j).svName & """ &" _
                   & " skipped, as it does not end with expected extention """ & strFileExtension & """"
       End If

--- a/Modules/asMain.ACM
+++ b/Modules/asMain.ACM
@@ -85,9 +85,8 @@ End Function
 ' @param        String The path to a SCC Addin repository. Must include trailing slash.
 ' @return       String Any errors are returned, if no errors occured returns vbNullString
 '************************************************
-Public Function ImportSilent(strSccSystem As String, strImportPath As String, Optional blnSkipMacrosAndExtras As Boolean = False) As String
+Public Function ImportSilent(strSccSystem As String, strImportPath As String, Optional blnSkipMacrosAndExtras As Boolean = False, Optional strLibrary As String = vbNullString, Optional blnSkipPrivate As Boolean = False) As String
   Dim strError As String
-  
   Select Case strSccSystem
     Case "SVN":
       SetSCCSystem sccSystemSubversion
@@ -112,17 +111,17 @@ Public Function ImportSilent(strSccSystem As String, strImportPath As String, Op
     UpdateObjectProperties (asObjectType.acExtra)     ' Extras
   End If
   
-  asPopulateTmpObjectsImport objTable, strImportPath & "Tables", modSCC.arrTables             ' Tables
-  asPopulateTmpObjectsImport objQuery, strImportPath & "Queries", modSCC.arrQueries           ' Queries
-  asPopulateTmpObjectsImport objForm, strImportPath & "Forms", modSCC.arrForms                ' Forms
-  asPopulateTmpObjectsImport objReport, strImportPath & "Reports", modSCC.arrReports          ' Reports
-  asPopulateTmpObjectsImport objModule, strImportPath & "Modules", modSCC.arrModules          ' Modules
-  asPopulateTmpObjectsImport objToolbar, strImportPath & "Toolbars", modSCC.arrToolbars       ' Toolbars
-  asPopulateTmpObjectsImport objReference, strImportPath & "References", modSCC.arrReferences ' References
-  asPopulateTmpObjectsImport objIMEXSpecs, strImportPath & "IMEXSpecs", modSCC.arrIMEXSpecs   ' Import Export Sepcs
+  asPopulateTmpObjectsImport objTable, strImportPath & "Tables", modSCC.arrTables, strLibrary, blnSkipPrivate             ' Tables
+  asPopulateTmpObjectsImport objQuery, strImportPath & "Queries", modSCC.arrQueries, strLibrary, blnSkipPrivate           ' Queries
+  asPopulateTmpObjectsImport objForm, strImportPath & "Forms", modSCC.arrForms, strLibrary, blnSkipPrivate                ' Forms
+  asPopulateTmpObjectsImport objReport, strImportPath & "Reports", modSCC.arrReports, strLibrary, blnSkipPrivate          ' Reports
+  asPopulateTmpObjectsImport objModule, strImportPath & "Modules", modSCC.arrModules, strLibrary, blnSkipPrivate          ' Modules
+  asPopulateTmpObjectsImport objToolbar, strImportPath & "Toolbars", modSCC.arrToolbars, strLibrary, blnSkipPrivate       ' Toolbars
+  asPopulateTmpObjectsImport objReference, strImportPath & "References", modSCC.arrReferences, strLibrary, blnSkipPrivate ' References
+  asPopulateTmpObjectsImport objIMEXSpecs, strImportPath & "IMEXSpecs", modSCC.arrIMEXSpecs, strLibrary, blnSkipPrivate   ' Import Export Sepcs
   If Not blnSkipMacrosAndExtras Then
-    asPopulateTmpObjectsImport objMacro, strImportPath & "Macros", modSCC.arrMacros             ' Macros
-    asPopulateTmpObjectsImport objExtra, strImportPath & "Extras", modSCC.arrExtras             ' Extras
+    asPopulateTmpObjectsImport objMacro, strImportPath & "Macros", modSCC.arrMacros, strLibrary, blnSkipPrivate             ' Macros
+    asPopulateTmpObjectsImport objExtra, strImportPath & "Extras", modSCC.arrExtras, strLibrary, blnSkipPrivate             ' Extras
   End If
   
   ' If there are broken references, reimport the references even if they are unchanged
@@ -130,17 +129,17 @@ Public Function ImportSilent(strSccSystem As String, strImportPath As String, Op
     CodeDb.Execute "UPDATE MSysSCCTmpObjects IN '" & CurrentDb.Name & "' SET selected = TRUE WHERE objType = " & CInt(objReference)
   End If
   
-  asImportObjects objTable, strImportPath & "Tables\", strError         ' Tables
-  asImportObjects objQuery, strImportPath & "Queries\", strError        ' Queries
-  asImportObjects objForm, strImportPath & "Forms\", strError           ' Forms
-  asImportObjects objReport, strImportPath & "Reports\", strError       ' Reports
-  asImportObjects objModule, strImportPath & "Modules\", strError       ' Modules
-  asImportObjects objToolbar, strImportPath & "Toolbars\", strError     ' Toolbars
-  asImportObjects objReference, strImportPath & "References\", strError, strImportRootPath:=strImportPath   ' References
-  asImportObjects objIMEXSpecs, strImportPath & "IMEXSpecs\", strError  ' Import Export Specs
+  asImportObjects objTable, strImportPath & "Tables\", strError, , strLibrary        ' Tables
+  asImportObjects objQuery, strImportPath & "Queries\", strError, , strLibrary       ' Queries
+  asImportObjects objForm, strImportPath & "Forms\", strError, , strLibrary          ' Forms
+  asImportObjects objReport, strImportPath & "Reports\", strError, , strLibrary      ' Reports
+  asImportObjects objModule, strImportPath & "Modules\", strError, , strLibrary      ' Modules
+  asImportObjects objToolbar, strImportPath & "Toolbars\", strError, , strLibrary    ' Toolbars
+  asImportObjects objReference, strImportPath & "References\", strError, strImportPath, strLibrary   ' References
+  asImportObjects objIMEXSpecs, strImportPath & "IMEXSpecs\", strError, , strLibrary ' Import Export Specs
   If Not blnSkipMacrosAndExtras Then
-    asImportObjects objMacro, strImportPath & "Macros\", strError         ' Macros
-    asImportObjects objExtra, strImportPath & "Extras\", strError         ' Extras
+    asImportObjects objMacro, strImportPath & "Macros\", strError, , strLibrary        ' Macros
+    asImportObjects objExtra, strImportPath & "Extras\", strError, , strLibrary        ' Extras
   End If
   
   ImportSilent = strError
@@ -365,7 +364,7 @@ Public Function UpdateObjectProperties(oType As asObjectType) As Boolean
   UpdateObjectProperties = True
 End Function
 
-Private Sub UpdateStatusEntry(intDirection As Integer, objType As asObjectDBType, strName As String, intAction As Integer, Optional strPath As String = "")
+Private Sub UpdateStatusEntry(intDirection As Integer, objType As asObjectDBType, strName As String, intAction As Integer, Optional strPath As String = "", Optional strLibrary As String)
   Dim strQuery As String
   Dim db As DAO.Database
   Dim oSVNImport As SVNITEM
@@ -389,13 +388,13 @@ Private Sub UpdateStatusEntry(intDirection As Integer, objType As asObjectDBType
           ' If the object uses a checksum to check for changes use the checksum field in the table
           If objDBTypeUsesCheckSum(objType) Then
             'strObjModifiedChecksum = getObjectModifiedCheckSum(objType, strName)
-            strQuery = "INSERT INTO MSysSCCStatus (objType, objName, objImportVersion, objSCCChecksum, objImportChecksum) " & _
-                       "VALUES (" & objType & ", '" & strName & "', '" & oSVNImport.svRevision & "', '" & oSVNImport.svCheckSum & "', '" & oSVNImport.svCheckSum & "')"
+            strQuery = "INSERT INTO MSysSCCStatus (objType, objName, objImportVersion, objSCCChecksum, objImportChecksum, objSourceLibrary) " & _
+                       "VALUES (" & objType & ", '" & strName & "', '" & oSVNImport.svRevision & "', '" & oSVNImport.svCheckSum & "', '" & oSVNImport.svCheckSum & "', '" & strLibrary & "')"
           Else
             'dblObjModifiedDate = getObjectModifiedTimestamp(objType, strName)
             dblObjModifiedDate = CDbl(Now()) ' The SVNObjectProps table has not been updated yet
-            strQuery = "INSERT INTO MSysSCCStatus (objType, objName, objImportVersion, objSCCChecksum, objImportDate) " & _
-                       "VALUES (" & objType & ", '" & strName & "', '" & oSVNImport.svRevision & "', '" & oSVNImport.svCheckSum & "', " & str$(dblObjModifiedDate) & ")"
+            strQuery = "INSERT INTO MSysSCCStatus (objType, objName, objImportVersion, objSCCChecksum, objImportDate, objSourceLibrary) " & _
+                       "VALUES (" & objType & ", '" & strName & "', '" & oSVNImport.svRevision & "', '" & oSVNImport.svCheckSum & "', " & str$(dblObjModifiedDate) & ", '" & strLibrary & "')"
           End If
         
         Case asCommit
@@ -439,12 +438,12 @@ Private Sub UpdateStatusEntry(intDirection As Integer, objType As asObjectDBType
           ' If the object uses a checksum to check for changes use the checksum fiedl in the table
           If objDBTypeUsesCheckSum(objType) Then
             strObjModifiedChecksum = getObjectModifiedCheckSum(objType, strName)
-            strQuery = "INSERT INTO MSysSCCStatus (objType, objName, objImportVersion, objSCCChecksum, objImportChecksum, objStatusUnknown) " & _
-                       "VALUES (" & objType & ", '" & strName & "', '0', '0', '" & strObjModifiedChecksum & "', True)"
+            strQuery = "INSERT INTO MSysSCCStatus (objType, objName, objImportVersion, objSCCChecksum, objImportChecksum, objStatusUnknown, objSourceLibrary) " & _
+                       "VALUES (" & objType & ", '" & strName & "', '0', '0', '" & strObjModifiedChecksum & "', True, '" & strLibrary & "')"
           Else
             dblObjModifiedDate = getObjectModifiedTimestamp(objType, strName)
-            strQuery = "INSERT INTO MSysSCCStatus (objType, objName, objImportVersion, objSCCChecksum, objImportDate, objStatusUnknown) " & _
-                       "VALUES (" & objType & ", '" & strName & "', '0', '0', " & str$(dblObjModifiedDate) & ", True)"
+            strQuery = "INSERT INTO MSysSCCStatus (objType, objName, objImportVersion, objSCCChecksum, objImportDate, objStatusUnknown, objSourceLibrary) " & _
+                       "VALUES (" & objType & ", '" & strName & "', '0', '0', " & str$(dblObjModifiedDate) & ", True, '" & strLibrary & "')"
           End If
         
         Case asCommit
@@ -556,10 +555,13 @@ Private Sub asExportObjects(objExportType As asObjectDBType, strExportPath As St
   Dim rst As DAO.Recordset
   Dim strObjectType As String
   Dim strObjectFileName As String
-  Dim booSkipObject As Boolean
+  Dim blnSkipObject As Boolean
   
   Set db = CurrentDb()
-  Set rst = db.OpenRecordset("SELECT * FROM MSysSCCTmpObjects WHERE objType = " & objExportType & " AND selected = True", dbOpenDynaset)
+  Set rst = db.OpenRecordset("SELECT t.*, s.objSourceLibrary " & _
+                             "FROM MSysSCCTmpObjects t LEFT JOIN MSysSCCStatus s " & _
+                             "ON t.objType = s.objType AND t.objName = s.objName " & _
+                             "WHERE t.objType = " & objExportType & " AND selected = True", dbOpenDynaset)
   
   If Not rst.EOF Then
     asMkDir strExportPath
@@ -567,18 +569,25 @@ Private Sub asExportObjects(objExportType As asObjectDBType, strExportPath As St
   
   strObjectType = asGetObjectNiceName(objExportType)
   Do Until rst.EOF
-    booSkipObject = False
+    blnSkipObject = False
     ' Don't process the internal SQL queries that are stored in access
     If objExportType = objQuery And Left(rst!objName, 4) = "~sq_" Then
-      booSkipObject = True
+      blnSkipObject = True
     End If
     
     ' Don't process internal Access tables, (and the SVN status tables)
     If objExportType = objTable And Left(rst!objName, 4) = "MSys" Then
-      booSkipObject = True
+      blnSkipObject = True
     End If
     
-    If Not booSkipObject Then
+    If Not IsNull(rst("objSourceLibrary")) Then
+      If rst("objSourceLibrary") <> "" Then
+        AddResult "Cannot Export " & rst("objName") & " '" & strObjectFileName & "' - This object belongs to the '" & rst("objSourceLibrary") & "' library."
+        blnSkipObject = True
+      End If
+    End If
+    
+    If Not blnSkipObject Then
       strObjectFileName = winPathSpecialChars(rst!objName) & asGetObjectExportFileExtension(objExportType)
       
       SetStatus "Exporting " & strObjectType & " '" & rst!objName & "'"
@@ -781,7 +790,7 @@ Public Sub asUpdateVersionsFromExport(strExportPath As String)
          
 End Sub
 
-Private Sub asImportObject(objType As asObjectDBType, objName As String, objStatus As String, strImportPath As String, Optional strImportRootPath As String, Optional ByRef strError As String)
+Private Sub asImportObject(objType As asObjectDBType, objName As String, objStatus As String, strImportPath As String, Optional strImportRootPath As String, Optional ByRef strError As String, Optional strLibrary As String)
   Dim strImportFileName As String, strObjectType As String
   Dim strLoadError As String
 
@@ -798,7 +807,7 @@ Private Sub asImportObject(objType As asObjectDBType, objName As String, objStat
     Case "Deleted"
       SetStatus "Deleting " & strObjectType & " '" & objName & "' from " & appendSlash(strImportPath) & strImportFileName
       asDeleteObject objType, objName
-      UpdateStatusEntry asImport, objType, objName, asDelete
+      UpdateStatusEntry asImport, objType, objName, asDelete, , strLibrary
       
     Case "New"
       SetStatus "Importing " & strObjectType & " '" & objName & "' from " & appendSlash(strImportPath) & strImportFileName
@@ -807,7 +816,7 @@ Private Sub asImportObject(objType As asObjectDBType, objName As String, objStat
         AddResult "Error importing " & objName & ": " & strLoadError & vbCrLf, strError
         strLoadError = ""
       End If
-      UpdateStatusEntry asImport, objType, objName, asAdd, appendSlash(strImportPath) & strImportFileName
+      UpdateStatusEntry asImport, objType, objName, asAdd, appendSlash(strImportPath) & strImportFileName, strLibrary
       
     Case Else
       SetStatus "Importing " & strObjectType & " '" & objName & "' from " & appendSlash(strImportPath) & strImportFileName
@@ -816,7 +825,7 @@ Private Sub asImportObject(objType As asObjectDBType, objName As String, objStat
         AddResult "Error importing " & objName & ": " & strLoadError & vbCrLf
         strLoadError = ""
       End If
-      UpdateStatusEntry asImport, objType, objName, asCommit, appendSlash(strImportPath) & strImportFileName
+      UpdateStatusEntry asImport, objType, objName, asCommit, appendSlash(strImportPath) & strImportFileName, strLibrary
       
   End Select
 
@@ -893,7 +902,7 @@ Private Sub asDeleteObject(objType As asObjectDBType, objName As String)
 
 End Sub
 
-Private Sub asImportObjects(objImportType As asObjectDBType, strImportPath As String, Optional ByRef strError As String, Optional strImportRootPath As String)
+Private Sub asImportObjects(objImportType As asObjectDBType, strImportPath As String, Optional ByRef strError As String, Optional strImportRootPath As String, Optional strLibrary As String)
   On Error GoTo Err_asImportObjects
   
   Dim db As DAO.Database
@@ -910,7 +919,7 @@ Private Sub asImportObjects(objImportType As asObjectDBType, strImportPath As St
   
   ' Import all the objects
   Do Until rst.EOF
-    asImportObject rst!objType, rst!objName, rst!objStatus, strImportPath, strImportRootPath, strError
+    asImportObject rst!objType, rst!objName, rst!objStatus, strImportPath, strImportRootPath, strError, strLibrary
     rst.MoveNext
   Loop
 
@@ -1452,7 +1461,15 @@ Private Function EndsWith(strCheck As String, strMatch As String)
   EndsWith = (Mid(strCheck, Len(strCheck) - Len(strMatch) + 1) = strMatch)
 End Function
 
-Private Sub asPopulateTmpObjectsImport(objType As asObjectDBType, strImportPath As String, arrSVNItems() As SVNITEM)
+Private Function StartsWith(strCheck As String, strMatch As String)
+  If Len(strCheck) < Len(strMatch) Then
+    Exit Function
+  End If
+  
+  StartsWith = (Mid(strCheck, 1, Len(strMatch)) = strMatch)
+End Function
+
+Private Sub asPopulateTmpObjectsImport(objType As asObjectDBType, strImportPath As String, arrSVNItems() As SVNITEM, strLibrary As String, blnSkipPrivate As Boolean)
   Dim db As DAO.Database
   Dim rst1 As DAO.Recordset
   Dim rst2 As DAO.Recordset
@@ -1461,6 +1478,7 @@ Private Sub asPopulateTmpObjectsImport(objType As asObjectDBType, strImportPath 
   Dim strDeletedQuery As String
   Dim j As Integer
   Dim strFileExtension As String
+  Dim blnSkip As Boolean
   
   strFileExtension = asGetObjectExportFileExtension(objType)
   
@@ -1470,7 +1488,22 @@ Private Sub asPopulateTmpObjectsImport(objType As asObjectDBType, strImportPath 
   SCC_GetAllVersionsSubFolder strImportPath, arrSVNItems
   If (Not arrSVNItems) <> -1 Then ' check that the arr is not nothing before looping through it
     For j = LBound(arrSVNItems) To UBound(arrSVNItems)
-      If EndsWith(arrSVNItems(j).svName, strFileExtension) Then
+      blnSkip = False
+      
+      If blnSkipPrivate Then
+        If StartsWith(arrSVNItems(j).svName, "_") Then
+          blnSkip = True
+        End If
+      End If
+      
+      If Not EndsWith(arrSVNItems(j).svName, strFileExtension) Then
+        blnSkip = True
+      Else
+        AddResult asGetObjectNiceName(objType) & """" & arrSVNItems(j).svName & """ &" _
+                  & " skipped, as it does not end with expected extention """ & strFileExtension & """"
+      End If
+    
+      If Not blnSkip Then
         strObjName = winPathSpecialCharsDecode(Left$(arrSVNItems(j).svName, Len(arrSVNItems(j).svName) - 4))
         rst1.AddNew
         rst1!objName = strObjName
@@ -1490,9 +1523,6 @@ Private Sub asPopulateTmpObjectsImport(objType As asObjectDBType, strImportPath 
           Exit For
         End If
         On Error GoTo 0
-      Else
-        AddResult asGetObjectNiceName(objType) & """" & arrSVNItems(j).svName & """ &" _
-                  & " skipped, as it does not end with expected extention """ & strFileExtension & """"
       End If
     Next j
   End If
@@ -1504,7 +1534,8 @@ Private Sub asPopulateTmpObjectsImport(objType As asObjectDBType, strImportPath 
                     "ON S.objName = T.objName " & _
                     "AND S.objType = T.objType " & _
                     "WHERE T.objName Is Null " & _
-                    "AND S.objType = " & objType
+                    "AND S.objType = " & objType & " " & _
+                    "AND S.objSourceLibrary = """ & strLibrary & """"
   Set rst2 = db.OpenRecordset(strDeletedQuery)
   If rst2.RecordCount > 0 Then
     Do Until rst2.EOF
@@ -1554,16 +1585,16 @@ Public Sub asPopulateTmpObjectsTables(intDirection As Integer)
     Case asImport
       strImportPath = appendSlash(Application.Forms![Access SVN - Options].txtOutputLocation.Value)
     
-      If Application.Forms![Access SVN - Options].chkTables.Value = True Then asPopulateTmpObjectsImport objTable, strImportPath & "Tables", modSCC.arrTables                 ' Tables
-      If Application.Forms![Access SVN - Options].chkQueries.Value = True Then asPopulateTmpObjectsImport objQuery, strImportPath & "Queries", modSCC.arrQueries              ' Queries
-      If Application.Forms![Access SVN - Options].chkForms.Value = True Then asPopulateTmpObjectsImport objForm, strImportPath & "Forms", modSCC.arrForms                     ' Forms
-      If Application.Forms![Access SVN - Options].chkReports.Value = True Then asPopulateTmpObjectsImport objReport, strImportPath & "Reports", modSCC.arrReports             ' Reports
-      If Application.Forms![Access SVN - Options].chkMacros.Value = True Then asPopulateTmpObjectsImport objMacro, strImportPath & "Macros", modSCC.arrMacros                 ' Macros
-      If Application.Forms![Access SVN - Options].chkModules.Value = True Then asPopulateTmpObjectsImport objModule, strImportPath & "Modules", modSCC.arrModules             ' Modules
-      If Application.Forms![Access SVN - Options].chkCmdBars.Value = True Then asPopulateTmpObjectsImport objToolbar, strImportPath & "Toolbars", modSCC.arrToolbars          ' Toolbars
-      If Application.Forms![Access SVN - Options].chkExtras.Value = True Then asPopulateTmpObjectsImport objExtra, strImportPath & "Extras", modSCC.arrExtras                 ' Extras
-      If Application.Forms![Access SVN - Options].chkReferences.Value = True Then asPopulateTmpObjectsImport objReference, strImportPath & "References", modSCC.arrReferences ' References
-      If Application.Forms![Access SVN - Options].chkImportExport.Value = True Then asPopulateTmpObjectsImport objIMEXSpecs, strImportPath & "IMEXSpecs", modSCC.arrIMEXSpecs ' Import Export Sepcs
+      If Application.Forms![Access SVN - Options].chkTables.Value = True Then asPopulateTmpObjectsImport objTable, strImportPath & "Tables", modSCC.arrTables, vbNullString, False                 ' Tables
+      If Application.Forms![Access SVN - Options].chkQueries.Value = True Then asPopulateTmpObjectsImport objQuery, strImportPath & "Queries", modSCC.arrQueries, vbNullString, False               ' Queries
+      If Application.Forms![Access SVN - Options].chkForms.Value = True Then asPopulateTmpObjectsImport objForm, strImportPath & "Forms", modSCC.arrForms, vbNullString, False                      ' Forms
+      If Application.Forms![Access SVN - Options].chkReports.Value = True Then asPopulateTmpObjectsImport objReport, strImportPath & "Reports", modSCC.arrReports, vbNullString, False              ' Reports
+      If Application.Forms![Access SVN - Options].chkMacros.Value = True Then asPopulateTmpObjectsImport objMacro, strImportPath & "Macros", modSCC.arrMacros, vbNullString, False                  ' Macros
+      If Application.Forms![Access SVN - Options].chkModules.Value = True Then asPopulateTmpObjectsImport objModule, strImportPath & "Modules", modSCC.arrModules, vbNullString, False              ' Modules
+      If Application.Forms![Access SVN - Options].chkCmdBars.Value = True Then asPopulateTmpObjectsImport objToolbar, strImportPath & "Toolbars", modSCC.arrToolbars, vbNullString, False           ' Toolbars
+      If Application.Forms![Access SVN - Options].chkExtras.Value = True Then asPopulateTmpObjectsImport objExtra, strImportPath & "Extras", modSCC.arrExtras, vbNullString, False                  ' Extras
+      If Application.Forms![Access SVN - Options].chkReferences.Value = True Then asPopulateTmpObjectsImport objReference, strImportPath & "References", modSCC.arrReferences, vbNullString, False  ' References
+      If Application.Forms![Access SVN - Options].chkImportExport.Value = True Then asPopulateTmpObjectsImport objIMEXSpecs, strImportPath & "IMEXSpecs", modSCC.arrIMEXSpecs, vbNullString, False  ' Import Export Sepcs
     
     Case Else
       MsgBox "This function was not called with a valid import export type.", vbExclamation, "Access - SVN"

--- a/Modules/asMain.ACM
+++ b/Modules/asMain.ACM
@@ -643,6 +643,7 @@ End Sub
 Private Sub asExportAllObjects(strExportPath As String)
     Dim enmEncode As asEncode
     Dim blnRemoveGUIDs As Boolean
+    Dim frmOptions As [Form_Access SVN - Options]
     
     On Error GoTo Err_OutputToText
     
@@ -656,17 +657,17 @@ Private Sub asExportAllObjects(strExportPath As String)
 
     
     blnRemoveGUIDs = GetConfigValue("Remove GUIDs", strExportPath)
-          
-    If Application.Forms![Access SVN - Options].chkTables.Value = True Then asExportObjects objTable, strExportPath & "Tables", enmEncode, blnRemoveGUIDs
-    If Application.Forms![Access SVN - Options].chkQueries.Value = True Then asExportObjects objQuery, strExportPath & "Queries", enmEncode, blnRemoveGUIDs
-    If Application.Forms![Access SVN - Options].chkForms.Value = True Then asExportObjects objForm, strExportPath & "Forms", enmEncode, blnRemoveGUIDs
-    If Application.Forms![Access SVN - Options].chkReports.Value = True Then asExportObjects objReport, strExportPath & "Reports", enmEncode, blnRemoveGUIDs
-    If Application.Forms![Access SVN - Options].chkMacros.Value = True Then asExportObjects objMacro, strExportPath & "Macros", enmEncode, blnRemoveGUIDs
-    If Application.Forms![Access SVN - Options].chkModules.Value = True Then asExportObjects objModule, strExportPath & "Modules", enmEncode, blnRemoveGUIDs
-    If Application.Forms![Access SVN - Options].chkCmdBars.Value = True Then asExportObjects objToolbar, strExportPath & "Toolbars", enmEncode, blnRemoveGUIDs
-    If Application.Forms![Access SVN - Options].chkExtras.Value = True Then asExportObjects objExtra, strExportPath & "Extras", enmEncode, blnRemoveGUIDs
-    If Application.Forms![Access SVN - Options].chkReferences.Value = True Then asExportObjects objReference, strExportPath & "References", enmEncode, blnRemoveGUIDs
-    If Application.Forms![Access SVN - Options].chkImportExport.Value = True Then asExportObjects objIMEXSpecs, strExportPath & "IMEXSpecs", enmEncode, blnRemoveGUIDs
+    Set frmOptions = Application.Forms![Access SVN - Options]
+    If frmOptions.chkTables.Value = True Then asExportObjects objTable, strExportPath & "Tables", enmEncode, blnRemoveGUIDs
+    If frmOptions.chkQueries.Value = True Then asExportObjects objQuery, strExportPath & "Queries", enmEncode, blnRemoveGUIDs
+    If frmOptions.chkForms.Value = True Then asExportObjects objForm, strExportPath & "Forms", enmEncode, blnRemoveGUIDs
+    If frmOptions.chkReports.Value = True Then asExportObjects objReport, strExportPath & "Reports", enmEncode, blnRemoveGUIDs
+    If frmOptions.chkMacros.Value = True Then asExportObjects objMacro, strExportPath & "Macros", enmEncode, blnRemoveGUIDs
+    If frmOptions.chkModules.Value = True Then asExportObjects objModule, strExportPath & "Modules", enmEncode, blnRemoveGUIDs
+    If frmOptions.chkCmdBars.Value = True Then asExportObjects objToolbar, strExportPath & "Toolbars", enmEncode, blnRemoveGUIDs
+    If frmOptions.chkExtras.Value = True Then asExportObjects objExtra, strExportPath & "Extras", enmEncode, blnRemoveGUIDs
+    If frmOptions.chkReferences.Value = True Then asExportObjects objReference, strExportPath & "References", enmEncode, blnRemoveGUIDs
+    If frmOptions.chkImportExport.Value = True Then asExportObjects objIMEXSpecs, strExportPath & "IMEXSpecs", enmEncode, blnRemoveGUIDs
 
 Exit_OutputToText:
     asPurgeTmpObjectsTables
@@ -954,17 +955,19 @@ End Sub
 
 Private Sub asImportAllFromText(strExportPath As String)
     On Error GoTo Err_ImportAllFromText
+    Dim frmOptions As [Form_Access SVN - Options]
     
-    If Application.Forms![Access SVN - Options].chkTables.Value = True Then asImportObjects objTable, strExportPath & "Tables\"             ' Tables
-    If Application.Forms![Access SVN - Options].chkQueries.Value = True Then asImportObjects objQuery, strExportPath & "Queries\"           ' Queries
-    If Application.Forms![Access SVN - Options].chkForms.Value = True Then asImportObjects objForm, strExportPath & "Forms\"                ' Forms
-    If Application.Forms![Access SVN - Options].chkReports.Value = True Then asImportObjects objReport, strExportPath & "Reports\"          ' Reports
-    If Application.Forms![Access SVN - Options].chkMacros.Value = True Then asImportObjects objMacro, strExportPath & "Macros\"             ' Macros
-    If Application.Forms![Access SVN - Options].chkModules.Value = True Then asImportObjects objModule, strExportPath & "Modules\"          ' Modules
-    If Application.Forms![Access SVN - Options].chkCmdBars.Value = True Then asImportObjects objToolbar, strExportPath & "Toolbars\"        ' Toolbars
-    If Application.Forms![Access SVN - Options].chkExtras.Value = True Then asImportObjects objExtra, strExportPath & "Extras\"             ' Extras
-    If Application.Forms![Access SVN - Options].chkReferences.Value = True Then asImportObjects objReference, strExportPath & "References\", strImportRootPath:=strExportPath ' References
-    If Application.Forms![Access SVN - Options].chkImportExport.Value = True Then asImportObjects objIMEXSpecs, strExportPath & "IMEXSpecs\"   ' Import Export Specs
+    Set frmOptions = Application.Forms![Access SVN - Options].chkTables.Value
+    If frmOptions.chkTables.Value = True Then asImportObjects objTable, strExportPath & "Tables\"             ' Tables
+    If frmOptions.chkQueries.Value = True Then asImportObjects objQuery, strExportPath & "Queries\"           ' Queries
+    If frmOptions.chkForms.Value = True Then asImportObjects objForm, strExportPath & "Forms\"                ' Forms
+    If frmOptions.chkReports.Value = True Then asImportObjects objReport, strExportPath & "Reports\"          ' Reports
+    If frmOptions.chkMacros.Value = True Then asImportObjects objMacro, strExportPath & "Macros\"             ' Macros
+    If frmOptions.chkModules.Value = True Then asImportObjects objModule, strExportPath & "Modules\"          ' Modules
+    If frmOptions.chkCmdBars.Value = True Then asImportObjects objToolbar, strExportPath & "Toolbars\"        ' Toolbars
+    If frmOptions.chkExtras.Value = True Then asImportObjects objExtra, strExportPath & "Extras\"             ' Extras
+    If frmOptions.chkReferences.Value = True Then asImportObjects objReference, strExportPath & "References\", strImportRootPath:=strExportPath ' References
+    If frmOptions.chkImportExport.Value = True Then asImportObjects objIMEXSpecs, strExportPath & "IMEXSpecs\"   ' Import Export Specs
     
     Echo True
     MsgBox "All items imported.", vbInformation, "Access SVN"
@@ -1554,47 +1557,50 @@ End Sub
 
 Public Sub asPopulateTmpObjectsTables(intDirection As Integer)
   Dim strImportPath As String
+  Dim frmOptions As [Form_Access SVN - Options]
   
   DoCmd.Hourglass True
-    
+  
+  Set frmOptions = Application.Forms![Access SVN - Options]
+
   ' Update the SVN Object Properties table with relevant data for the ticket object types
-  If Application.Forms![Access SVN - Options].chkTables.Value = True Then UpdateObjectProperties (asObjectType.acTable)        ' Tables
-  If Application.Forms![Access SVN - Options].chkQueries.Value = True Then UpdateObjectProperties (asObjectType.acQuery)       ' Queries
-  If Application.Forms![Access SVN - Options].chkForms.Value = True Then UpdateObjectProperties (asObjectType.acForm)          ' Forms
-  If Application.Forms![Access SVN - Options].chkReports.Value = True Then UpdateObjectProperties (asObjectType.acReport)      ' Reports
-  If Application.Forms![Access SVN - Options].chkMacros.Value = True Then UpdateObjectProperties (asObjectType.acMacro)        ' Macros
-  If Application.Forms![Access SVN - Options].chkModules.Value = True Then UpdateObjectProperties (asObjectType.acModule)      ' Modules
-  If Application.Forms![Access SVN - Options].chkCmdBars.Value = True Then UpdateObjectProperties (asObjectType.acToolbar)     ' Toolbars
-  If Application.Forms![Access SVN - Options].chkExtras.Value = True Then UpdateObjectProperties (asObjectType.acExtra)        ' Extras
-  If Application.Forms![Access SVN - Options].chkReferences.Value = True Then UpdateObjectProperties (asObjectType.acReference) ' References
-  If Application.Forms![Access SVN - Options].chkImportExport.Value = True Then UpdateObjectProperties (asObjectType.acIMEXSpecs)  ' Import Export Specs
+  If frmOptions.chkTables.Value = True Then UpdateObjectProperties (asObjectType.acTable)        ' Tables
+  If frmOptions.chkQueries.Value = True Then UpdateObjectProperties (asObjectType.acQuery)       ' Queries
+  If frmOptions.chkForms.Value = True Then UpdateObjectProperties (asObjectType.acForm)          ' Forms
+  If frmOptions.chkReports.Value = True Then UpdateObjectProperties (asObjectType.acReport)      ' Reports
+  If frmOptions.chkMacros.Value = True Then UpdateObjectProperties (asObjectType.acMacro)        ' Macros
+  If frmOptions.chkModules.Value = True Then UpdateObjectProperties (asObjectType.acModule)      ' Modules
+  If frmOptions.chkCmdBars.Value = True Then UpdateObjectProperties (asObjectType.acToolbar)     ' Toolbars
+  If frmOptions.chkExtras.Value = True Then UpdateObjectProperties (asObjectType.acExtra)        ' Extras
+  If frmOptions.chkReferences.Value = True Then UpdateObjectProperties (asObjectType.acReference) ' References
+  If frmOptions.chkImportExport.Value = True Then UpdateObjectProperties (asObjectType.acIMEXSpecs)  ' Import Export Specs
   
   Select Case intDirection
     Case asExport
-      If Application.Forms![Access SVN - Options].chkTables.Value = True Then asPopulateTmpObjectsExport (objTable)         ' Tables
-      If Application.Forms![Access SVN - Options].chkQueries.Value = True Then asPopulateTmpObjectsExport (objQuery)        ' Queries
-      If Application.Forms![Access SVN - Options].chkForms.Value = True Then asPopulateTmpObjectsExport (objForm)           ' Forms
-      If Application.Forms![Access SVN - Options].chkReports.Value = True Then asPopulateTmpObjectsExport (objReport)       ' Reports
-      If Application.Forms![Access SVN - Options].chkMacros.Value = True Then asPopulateTmpObjectsExport (objMacro)         ' Macros
-      If Application.Forms![Access SVN - Options].chkModules.Value = True Then asPopulateTmpObjectsExport (objModule)       ' Modules
-      If Application.Forms![Access SVN - Options].chkCmdBars.Value = True Then asPopulateTmpObjectsExport (objToolbar)      ' Toolbars
-      If Application.Forms![Access SVN - Options].chkExtras.Value = True Then asPopulateTmpObjectsExport (objExtra)         ' Extras
-      If Application.Forms![Access SVN - Options].chkReferences.Value = True Then asPopulateTmpObjectsExport (objReference) ' References
-      If Application.Forms![Access SVN - Options].chkImportExport.Value = True Then asPopulateTmpObjectsExport (objIMEXSpecs) ' Import Export Specs
+      If frmOptions.chkTables.Value = True Then asPopulateTmpObjectsExport (objTable)         ' Tables
+      If frmOptions.chkQueries.Value = True Then asPopulateTmpObjectsExport (objQuery)        ' Queries
+      If frmOptions.chkForms.Value = True Then asPopulateTmpObjectsExport (objForm)           ' Forms
+      If frmOptions.chkReports.Value = True Then asPopulateTmpObjectsExport (objReport)       ' Reports
+      If frmOptions.chkMacros.Value = True Then asPopulateTmpObjectsExport (objMacro)         ' Macros
+      If frmOptions.chkModules.Value = True Then asPopulateTmpObjectsExport (objModule)       ' Modules
+      If frmOptions.chkCmdBars.Value = True Then asPopulateTmpObjectsExport (objToolbar)      ' Toolbars
+      If frmOptions.chkExtras.Value = True Then asPopulateTmpObjectsExport (objExtra)         ' Extras
+      If frmOptions.chkReferences.Value = True Then asPopulateTmpObjectsExport (objReference) ' References
+      If frmOptions.chkImportExport.Value = True Then asPopulateTmpObjectsExport (objIMEXSpecs) ' Import Export Specs
     
     Case asImport
-      strImportPath = appendSlash(Application.Forms![Access SVN - Options].txtOutputLocation.Value)
+      strImportPath = appendSlash(frmOptions.txtOutputLocation.Value)
     
-      If Application.Forms![Access SVN - Options].chkTables.Value = True Then asPopulateTmpObjectsImport objTable, strImportPath & "Tables", modSCC.arrTables, vbNullString, False                 ' Tables
-      If Application.Forms![Access SVN - Options].chkQueries.Value = True Then asPopulateTmpObjectsImport objQuery, strImportPath & "Queries", modSCC.arrQueries, vbNullString, False               ' Queries
-      If Application.Forms![Access SVN - Options].chkForms.Value = True Then asPopulateTmpObjectsImport objForm, strImportPath & "Forms", modSCC.arrForms, vbNullString, False                      ' Forms
-      If Application.Forms![Access SVN - Options].chkReports.Value = True Then asPopulateTmpObjectsImport objReport, strImportPath & "Reports", modSCC.arrReports, vbNullString, False              ' Reports
-      If Application.Forms![Access SVN - Options].chkMacros.Value = True Then asPopulateTmpObjectsImport objMacro, strImportPath & "Macros", modSCC.arrMacros, vbNullString, False                  ' Macros
-      If Application.Forms![Access SVN - Options].chkModules.Value = True Then asPopulateTmpObjectsImport objModule, strImportPath & "Modules", modSCC.arrModules, vbNullString, False              ' Modules
-      If Application.Forms![Access SVN - Options].chkCmdBars.Value = True Then asPopulateTmpObjectsImport objToolbar, strImportPath & "Toolbars", modSCC.arrToolbars, vbNullString, False           ' Toolbars
-      If Application.Forms![Access SVN - Options].chkExtras.Value = True Then asPopulateTmpObjectsImport objExtra, strImportPath & "Extras", modSCC.arrExtras, vbNullString, False                  ' Extras
-      If Application.Forms![Access SVN - Options].chkReferences.Value = True Then asPopulateTmpObjectsImport objReference, strImportPath & "References", modSCC.arrReferences, vbNullString, False  ' References
-      If Application.Forms![Access SVN - Options].chkImportExport.Value = True Then asPopulateTmpObjectsImport objIMEXSpecs, strImportPath & "IMEXSpecs", modSCC.arrIMEXSpecs, vbNullString, False  ' Import Export Sepcs
+      If frmOptions.chkTables.Value = True Then asPopulateTmpObjectsImport objTable, strImportPath & "Tables", modSCC.arrTables, vbNullString, False                 ' Tables
+      If frmOptions.chkQueries.Value = True Then asPopulateTmpObjectsImport objQuery, strImportPath & "Queries", modSCC.arrQueries, vbNullString, False               ' Queries
+      If frmOptions.chkForms.Value = True Then asPopulateTmpObjectsImport objForm, strImportPath & "Forms", modSCC.arrForms, vbNullString, False                      ' Forms
+      If frmOptions.chkReports.Value = True Then asPopulateTmpObjectsImport objReport, strImportPath & "Reports", modSCC.arrReports, vbNullString, False              ' Reports
+      If frmOptions.chkMacros.Value = True Then asPopulateTmpObjectsImport objMacro, strImportPath & "Macros", modSCC.arrMacros, vbNullString, False                  ' Macros
+      If frmOptions.chkModules.Value = True Then asPopulateTmpObjectsImport objModule, strImportPath & "Modules", modSCC.arrModules, vbNullString, False              ' Modules
+      If frmOptions.chkCmdBars.Value = True Then asPopulateTmpObjectsImport objToolbar, strImportPath & "Toolbars", modSCC.arrToolbars, vbNullString, False           ' Toolbars
+      If frmOptions.chkExtras.Value = True Then asPopulateTmpObjectsImport objExtra, strImportPath & "Extras", modSCC.arrExtras, vbNullString, False                  ' Extras
+      If frmOptions.chkReferences.Value = True Then asPopulateTmpObjectsImport objReference, strImportPath & "References", modSCC.arrReferences, vbNullString, False  ' References
+      If frmOptions.chkImportExport.Value = True Then asPopulateTmpObjectsImport objIMEXSpecs, strImportPath & "IMEXSpecs", modSCC.arrIMEXSpecs, vbNullString, False  ' Import Export Sepcs
     
     Case Else
       MsgBox "This function was not called with a valid import export type.", vbExclamation, "Access - SVN"


### PR DESCRIPTION
```
- Correctly detect deleted files from a Library
- Do not allow export of Library objects
- Add option to not import 'private' objects (those prefixed with "_")
- Store `Library` in `MSysSCCPrefs`, this is currently unused, but can be
  used by external tools to store metadata i.e. `LastCheckoutVersion` about a
  library

Other changes
- Remove unneeded `InFields` checks, this is checked in `AddField`
- Remove unused `fd` variables
- use `frmOptions` variable to streamline reading control values
```
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x-ware-ltd/access-scc-addin/71)
<!-- Reviewable:end -->
